### PR TITLE
fix videodisplay detction  on osx (was always disabled)

### DIFF
--- a/configure
+++ b/configure
@@ -6685,8 +6685,6 @@ fi
 
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for X11 using dubious methods..." >&5
 $as_echo_n "checking for X11 using dubious methods...... " >&6; }
-
-		a=0
 		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <X11/Xlib.h>

--- a/configure.in
+++ b/configure.in
@@ -576,8 +576,6 @@ CHECK_FOR_OPTION(videodisplay,[
 		# AC_CHECK_LIB(GLU,gluGetString, [], [a=1])
 
 		AC_MSG_CHECKING([for X11 using dubious methods...])
-
-		a=0
 		AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <X11/Xlib.h>
 		int main()
 		{


### PR DESCRIPTION
it's related to issue #7
