### PR TITLE
Fix portability issues

### DIFF
--- a/cvd/gl_helpers.h
+++ b/cvd/gl_helpers.h
@@ -14,6 +14,7 @@
 #include <cvd/rgba.h>
 #include <cvd/config.h>
 #ifdef WIN32
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/cvd/image_io.h
+++ b/cvd/image_io.h
@@ -181,12 +181,18 @@ namespace CVD
 
 	  if(c == 'P')
 	    CVD::Internal::readImage<I, PNM::Reader>(im, i);
+#ifdef CVD_HAVE_JPEG
 	  else if(c == 0xff)
 	    CVD::Internal::readImage<I, JPEG::reader>(im, i);
+#endif
+#ifdef CVD_HAVE_TIFF
 	  else if(c == 'I' || c == 'M') //Little or big endian TIFF
 	    CVD::Internal::readImage<I, TIFF::tiff_reader>(im, i);
+#endif
+#ifdef CVD_HAVE_PNG
 	  else if(c == 0x89)
 	    CVD::Internal::readImage<I, PNG::png_reader>(im, i);
+#endif
 	  else if(c == 'B')
 	    CVD::Internal::readImage<I, BMP::Reader>(im, i);
 	  else if(c == 'S')

--- a/cvd/internal/io/jpeg.h
+++ b/cvd/internal/io/jpeg.h
@@ -1,7 +1,6 @@
 #ifndef PNM_JPEG_H
 #define PNM_JPEG_H
-#include <cvd/config.h>
-#ifdef CVD_HAVE_JPEG
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -86,5 +85,4 @@ namespace JPEG
 
 }
 }
-#endif
 #endif

--- a/cvd/internal/io/jpeg.h
+++ b/cvd/internal/io/jpeg.h
@@ -1,6 +1,7 @@
 #ifndef PNM_JPEG_H
 #define PNM_JPEG_H
-
+#include <cvd/config.h>
+#ifdef CVD_HAVE_JPEG
 #include <iostream>
 #include <string>
 #include <vector>
@@ -85,5 +86,5 @@ namespace JPEG
 
 }
 }
-
+#endif
 #endif

--- a/cvd/internal/io/png.h
+++ b/cvd/internal/io/png.h
@@ -1,5 +1,7 @@
 #ifndef CVD_INTERNAL_IO_PNG_H
 #define CVD_INTERNAL_IO_PNG_H
+#include <cvd/config.h>
+#ifdef CVD_HAVE_PNG
 #include <iostream>
 #include <vector>
 #include <string>
@@ -132,4 +134,5 @@ class png_writer
 
 
 }}
+#endif
 #endif

--- a/cvd/internal/io/png.h
+++ b/cvd/internal/io/png.h
@@ -1,7 +1,6 @@
 #ifndef CVD_INTERNAL_IO_PNG_H
 #define CVD_INTERNAL_IO_PNG_H
-#include <cvd/config.h>
-#ifdef CVD_HAVE_PNG
+
 #include <iostream>
 #include <vector>
 #include <string>
@@ -134,5 +133,4 @@ class png_writer
 
 
 }}
-#endif
 #endif

--- a/cvd/internal/io/tiff.h
+++ b/cvd/internal/io/tiff.h
@@ -1,6 +1,7 @@
 #ifndef PNM_TIFF
 #define PNM_TIFF
-
+#include <cvd/config.h>
+#ifdef CVD_HAVE_TIFF
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -159,4 +160,5 @@ namespace TIFF
 
 }
 }
+#endif
 #endif

--- a/cvd/internal/io/tiff.h
+++ b/cvd/internal/io/tiff.h
@@ -1,7 +1,6 @@
 #ifndef PNM_TIFF
 #define PNM_TIFF
-#include <cvd/config.h>
-#ifdef CVD_HAVE_TIFF
+
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -160,5 +159,4 @@ namespace TIFF
 
 }
 }
-#endif
 #endif

--- a/cvd/morphology.h
+++ b/cvd/morphology.h
@@ -4,6 +4,7 @@
 #include <cvd/vision_exceptions.h>
 #include <cvd/vision.h>
 #include <cvd/image.h>
+#include <functional>
 #include <map>
 #include <vector>
 

--- a/cvd/readaheadvideobuffer.h
+++ b/cvd/readaheadvideobuffer.h
@@ -9,7 +9,7 @@
 
 namespace CVD {
 #ifndef CVD_HAVE_PTHREAD
-#warning ReadAheadVideoBuffer will not do any read-ahead because threads are not supported in this build
+#pragma message("ReadAheadVideoBuffer will not do any read - ahead because threads are not supported in this build")
 	template <class T> 
 		class ReadAheadVideoBuffer : public VideoBuffer<T>
 	{

--- a/cvd/timer.h
+++ b/cvd/timer.h
@@ -7,6 +7,7 @@
 
 #ifndef __CVD_TIMER_H
 #define __CVD_TIMER_H
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <cassert>

--- a/cvd_src/bayer.cxx
+++ b/cvd_src/bayer.cxx
@@ -1,7 +1,12 @@
 #include <string.h>
 #include <cvd/colourspaces.h>
 #include <cvd/colourspace_convert.h>
+#if WIN32
+#include <Winsock2.h>
+#pragma comment(lib, "Ws2_32.lib")
+#else
 #include <arpa/inet.h>
+#endif
 //Written by Ethan
 //Modified by Olaf :)
 

--- a/cvd_src/gltext.cpp
+++ b/cvd_src/gltext.cpp
@@ -1,5 +1,6 @@
 #include <cvd/gl_helpers.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath> 
 #include <map>

--- a/cvd_src/image_io.cc
+++ b/cvd_src/image_io.cc
@@ -92,12 +92,18 @@ ImageType::ImageType string_to_image_type(const std::string& name)
 
 	if (suffix == "ps") 
 	        return  ImageType::PS;
- 	else if (suffix == "jpg" || suffix == "jpeg") 
+#ifdef CVD_HAVE_JPEG
+	else if (suffix == "jpg" || suffix == "jpeg")
 	         return  ImageType::JPEG;
- 	else if (suffix == "png") 
+#endif
+#ifdef CVD_HAVE_PNG
+	else if (suffix == "png")
 	         return  ImageType::PNG;
- 	else if (suffix == "tif" || suffix == "tiff")
+#endif
+#ifdef CVD_HAVE_TIFF
+	else if (suffix == "tif" || suffix == "tiff")
 	         return  ImageType::TIFF;
+#endif
 	else if (suffix == "eps")
 		return  ImageType::EPS;
 	else if (suffix == "bmp") 

--- a/cvd_src/image_io/jpeg.cxx
+++ b/cvd_src/image_io/jpeg.cxx
@@ -8,6 +8,7 @@ extern "C"{
 #include "cvd/image_io.h"
 #include "cvd_src/config_internal.h"
 using namespace std;
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 #include <setjmp.h>


### PR DESCRIPTION
Add missing header files that are transitively included on gcc, fix some build issues on Windows, and fix building if `lib{jpeg,png,tiff}` are not available.