### PR TITLE
Fix some CMake and Windows portability issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,16 @@ set(HEADERS
 	cvd/internal/gles1_types.h
 	cvd/internal/gl_types.h
 	cvd/internal/image_ref_implementation.hh
+	cvd/internal/io/bmp.h
+	cvd/internal/io/cvdimage.h
+	cvd/internal/io/fits.h
+	cvd/internal/io/jpeg.h
+	cvd/internal/io/parameter.h
+	cvd/internal/io/png.h
+	cvd/internal/io/pnm_grok.h
+	cvd/internal/io/save_postscript.h
+	cvd/internal/io/text.h
+	cvd/internal/io/tiff.h
 	cvd/internal/load_and_save.h
 	cvd/internal/name_builtin_types.h
 	cvd/internal/name_CVD_rgb_types.h

--- a/cmake/CVDConfig.cmake
+++ b/cmake/CVDConfig.cmake
@@ -17,7 +17,7 @@
 
 find_path(CVD_INCLUDE_DIR NAMES cvd/config.h PATH_SUFFIXES include)
 find_library(CVD_LIBRARY_RELEASE NAMES cvd PATH_SUFFIXES lib)
-find_library(CVD_LIBRARY_DEBUG NAMES cvdd PATH_SUFFIXES lib)
+find_library(CVD_LIBRARY_DEBUG NAMES cvd_debug PATH_SUFFIXES lib)
 
 select_library_configurations(CVD)
 mark_as_advanced(CVD_LIBRARY_RELEASE CVD_LIBRARY_DEBUG)

--- a/cvd/colourmap.h
+++ b/cvd/colourmap.h
@@ -6,7 +6,7 @@
 #include <cvd/internal/convert_pixel_types.h>
 #include <cvd/internal/rgb_components.h>
 
-#include <utility>
+#include <algorithm>
 
 namespace CVD
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,5 +9,9 @@ add_test(NAME distance_transform_test COMMAND distance_transform_test)
 add_executable(fast_corner_test fast_corner_test.cc)
 add_test(NAME fast_corner_test COMMAND fast_corner_test)
 
+if(WIN32)
+	add_compile_options(/bigobj)
+endif()
+
 add_executable(load_and_save load_and_save.cc)
 add_test(NAME load_and_save COMMAND load_and_save)


### PR DESCRIPTION
Reinstates the `internal/io` header files which were missing from the `CMakeLists.txt` file.
Fixes the incorrect debug library name in the `CVDConfig.cmake` file.
Fixes the incorrect header file for `std::max` in `colourmap.h`.
Fixes the debug build of the unit tests in Windows, which was failing with an object file size error.