### PR TITLE
Refactor CMakeLists for better style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(TooN)
 find_package(X11)
 find_package(dc1394v2)
 find_package(OpenGL)
+find_package(Threads REQUIRED)
 
 # Detect endianness
 
@@ -89,8 +90,6 @@ set(HEADERS
 	cvd/bgrx.h
 	cvd/bresenham.h
 	cvd/byte.h
-	cvd/camera.h
-	cvd/canny.h
 	cvd/colourmap.h
 	cvd/colourspace.h
 	cvd/colourspacebuffer.h
@@ -106,7 +105,6 @@ set(HEADERS
 	cvd/distance_transform.h
 	cvd/documentation.h
 	cvd/draw.h
-	cvd/esm.h
 	cvd/exceptions.h
 	cvd/fast_corner.h
 	cvd/gles1_helpers.h
@@ -118,7 +116,6 @@ set(HEADERS
 	cvd/image.h
 	cvd/image_convert.h
 	cvd/image_convert_fwd.h
-	cvd/image_interpolate.h
 	cvd/image_io.h
 	cvd/image_ref.h
 	cvd/integral_image.h
@@ -138,7 +135,6 @@ set(HEADERS
 	cvd/timeddiskbuffer.h
 	cvd/timer.h
 	cvd/utility.h
-	cvd/vector_image_ref.h
 	cvd/videobuffer.h
 	cvd/videobufferflags.h
 	cvd/videobufferwithdata.h
@@ -185,7 +181,6 @@ if(dc1394_FOUND)
 		cvd/Linux/dvbuffer.h
 		cvd/Linux/dvbuffer3.h
 		cvd/Linux/dvframe.h)
-	link_libraries(${dc1394_LIBRARIES})
 else()
 	list(APPEND SRCS
 		cvd_src/videosource_nodvbuffer.cc)
@@ -203,9 +198,7 @@ if(OpenGL_FOUND)
 
 		set(CVD_HAVE_GLWINDOW ON)
 		set(CVD_HAVE_VIDEODISPLAY ON)
-		link_libraries(${X11_LIBRARIES})
 	endif()
-	link_libraries(${OPENGL_LIBRARIES})
 endif()
 
 # Platform-specific source files, headers and definitions.
@@ -215,19 +208,11 @@ if(WIN32)
 		cvd_src/Win32/glwindow.cpp)
 	set(CVD_HAVE_GLOB OFF)
 	set(CVD_HAVE_GLWINDOW ON)
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else()
-    #I'm not really sure this is the correct solution?
-	#This will always force the compiler into c++14 mode
-	#even if it's in C++17 mode, I think.
-	add_compile_options(--std=c++14)
-
 	list(APPEND SRCS
 		cvd_src/globlist.cxx)
 		
 	set(CVD_HAVE_GLOB ON)
-	link_libraries(pthread)
-		
 endif()
 
 if(USE_V4L)
@@ -262,7 +247,6 @@ endif()
 
 
 if(TooN_FOUND)
-	include_directories("${TooN_INCLUDE_DIRS}")
 	set(CVD_HAVE_TOON ON)
 	list(APPEND SRCS
 		cvd_src/brezenham.cc
@@ -271,15 +255,18 @@ if(TooN_FOUND)
 		cvd_src/threepointpose.cpp)
 	list(APPEND HEADERS
 		cvd/brezenham.h
+		cvd/camera.h
+		cvd/canny.h
+		cvd/esm.h
+		cvd/image_interpolate.h
 		cvd/tensor_voting.h
+		cvd/vector_image_ref.h
 		cvd/geometry/threepointpose.h)
 else()
 	set(CVD_HAVE_TOON OFF)
 endif()
 
-if(JPEG_INCLUDE_DIR)
-	include_directories("${JPEG_INCLUDE_DIR}")
-	link_libraries(${JPEG_LIBRARIES})
+if(JPEG_FOUND)
 	set(CVD_HAVE_JPEG ON)
 	set(CVD_INTERNAL_JPEG_BUFFER_SIZE 1)
     list(APPEND SRCS cvd_src/image_io/jpeg.cxx)
@@ -288,9 +275,7 @@ else()
 	set(CVD_INTERNAL_JPEG_BUFFER_SIZE OFF)
 endif()
 
-if(TIFF_INCLUDE_DIRS)
-	include_directories("${TIFF_INCLUDE_DIRS}")
-	link_libraries(${TIFF_LIBRARIES})
+if(TIFF_FOUND)
 	set(CVD_HAVE_TIFF ON)
     list(APPEND SRCS
 		cvd_src/image_io/tiff.cxx
@@ -299,9 +284,7 @@ else()
 	set(CVD_HAVE_TIFF OFF)
 endif()
 
-if(PNG_INCLUDE_DIRS)
-	include_directories("${PNG_INCLUDE_DIRS}")
-	link_libraries(${PNG_LIBRARIES})
+if(PNG_FOUND)
 	set(CVD_HAVE_PNG ON)
     list(APPEND SRCS cvd_src/image_io/png.cc)
 else()
@@ -312,8 +295,39 @@ configure_file(cmake/config.h.in include/cvd/config.h)
 configure_file(cmake/config_internal.h.in include/cvd_src/config_internal.h)
 
 set(CMAKE_DEBUG_POSTFIX _debug)
-include_directories("${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/include")
 add_library(${PROJECT_NAME} ${SRCS} ${HEADERS})
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
+if(JPEG_FOUND)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${JPEG_INCLUDE_DIRS})
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${JPEG_LIBRARIES})
+endif()
+if(PNG_FOUND)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${PNG_INCLUDE_DIRS})
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${PNG_LIBRARIES})
+endif()
+if(TIFF_FOUND)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${TIFF_INCLUDE_DIRS})
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${TIFF_LIBRARIES})
+endif()
+if(OPENGL_FOUND)
+	target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::GL)
+endif()
+if(X11_FOUND)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${X11_INCLUDE_DIR})
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${X11_LIBRARIES})
+endif()
+if(dc1394v2_FOUND)
+	target_include_directories(${PROJECT_NAME} PUBLIC ${dc1394v2_INCLUDE_DIRS})
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${dc1394v2_LIBRARIES})
+endif()
+if(TooN_FOUND)
+	target_include_directories(${PROJECT_NAME} PUBLIC ${TooN_INCLUDE_DIRS})
+endif()
+if(WIN32)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
 
 install(TARGETS ${PROJECT_NAME} ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 foreach(file ${HEADERS})

--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,20 @@
 dependencies:
   pre:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    - sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
     - sudo apt-get update 
-    - sudo apt-get install g++-7 cmake
-    - sudo apt-get install cmake --only-upgrade -y
+    - sudo apt-get install g++-7
+    - curl -LO https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.sh
+    - bash ./cmake-3.11.4-Linux-x86_64.sh --prefix=cmake
   override:
-    - mkdir build
-    - cd build && CXX=g++-7 cmake -DCMAKE_BUILD_TYPE=Release .. && make && make test && cd ..
-    - rm -r build
+    - mkdir cmake_build
+    - ../cmake/cmake -DCMAKE_BUILD_TYPE=Release ..:
+        pwd: cmake_build
+        environment:
+        - CXX: g++-7
+    - make:
+        pwd: cmake_build
+    - make test:
+        pwd: cmake_build
     - ./configure CXX="g++-7 -fuse-ld=gold"
     - make -j 4
     - sudo make install
@@ -16,4 +22,3 @@ dependencies:
 test:
     override:
         - LD_LIBRARY_PATH=$PWD make test
-

--- a/cmake/Finddc1394v2.cmake
+++ b/cmake/Finddc1394v2.cmake
@@ -1,8 +1,8 @@
 #.rst:
-# Finddc1394
+# Finddc1394v2
 # --------
 #
-# Find the native TooN includes.
+# Find the native dc1394 v2 includes.
 #
 # Result Variables
 # ^^^^^^^^^^^^^^^^
@@ -11,18 +11,19 @@
 #
 # ::
 #
-#   TooN_INCLUDE_DIRS   - where to find the TooN includes.
-#   TooN_FOUND          - True if TooN found.
+#   dc1394v2_INCLUDE_DIRS - where to find the dc1394v2 includes.
+#   dc1394v2_LIBRARIES    - where to find the dc1394v2 libraries.
+#   dc1394v2_FOUND        - True if dc1394v2 found.
 
-find_path(dc1394v2_INCLUDE_DIR NAMES dc1394/control.h PATH_SUFFIXES include)
+find_path(dc1394_INCLUDE_DIR NAMES dc1394/control.h PATH_SUFFIXES include)
 
-find_library(dc1394v2_LIBRARY NAMES dc1394 PATH_SUFFIXES lib)
+find_library(dc1394_LIBRARY NAMES dc1394 PATH_SUFFIXES lib)
 find_library(raw1394_LIBRARY NAMES raw1394 PATH_SUFFIXES lib)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(dc1394 REQUIRED_VARS dc1394v2_INCLUDE_DIR dc1394v2_LIBRARY raw1394_LIBRARY)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(dc1394v2 REQUIRED_VARS dc1394_INCLUDE_DIR dc1394_LIBRARY raw1394_LIBRARY)
 
-if(dc1394_FOUND)
-    set(dc1394_INCLUDE_DIRS ${dc1394_INCLUDE_DIR})
-    set(dc1394_LIBRARIES ${dc1394v2_LIBRARY} ${raw1394_LIBRARY})
+if(dc1394v2_FOUND)
+    set(dc1394v2_INCLUDE_DIRS ${dc1394_INCLUDE_DIR})
+    set(dc1394v2_LIBRARIES ${dc1394_LIBRARY} ${raw1394_LIBRARY})
 endif()
 
-mark_as_advanced(dc1394_INCLUDE_DIR dc1394v2_LIBRARY)
+mark_as_advanced(dc1394_INCLUDE_DIR dc1394_LIBRARY raw1394_LIBRARY)


### PR DESCRIPTION
The existing CMakeLists file has some poor style choices. `add_definitions`, `link_libraries` _et al_ are better replaced with target-specific commands. The dc1394v2 module has poor naming conventions. Also, the set of include files includes some TooN-only files.

This change refactors the CMake code to address these issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edrosten/libcvd/46)
<!-- Reviewable:end -->
