### PR TITLE
 Fix bug in SSE2 version of fast detector

### DIFF
--- a/cvd/image.h
+++ b/cvd/image.h
@@ -217,8 +217,8 @@ template<class T> class BasicImageIterator
 		{ }
 
 		//Prevent automatic conversion from a pointer (ie Image::iterator)
-		explicit BasicImageIterator(T* end) 
-		:ptr(end),is_end(1),row_increment(0),total_width(0)
+		explicit BasicImageIterator(T* endptr) 
+		:ptr(endptr),is_end(1),row_increment(0),total_width(0)
 		{ }
 
 	protected:

--- a/cvd_src/SSE2/faster_corner_10.cxx
+++ b/cvd_src/SSE2/faster_corner_10.cxx
@@ -16,7 +16,7 @@ namespace CVD
     template <bool Aligned> void faster_corner_detect_10(const BasicImage<byte>& I, std::vector<ImageRef>& corners, const int barrier)
     {
 	const int w = I.size().x;
-	const int stride = 3*w;
+	const int stride = I.row_stride();
  
 	const __m128i barriers = _mm_set1_epi8((byte)barrier);
 

--- a/cvd_src/SSE2/faster_corner_12.cxx
+++ b/cvd_src/SSE2/faster_corner_12.cxx
@@ -49,7 +49,7 @@ namespace CVD
     template <bool Aligned> void faster_corner_detect_12(const BasicImage<byte>& I, std::vector<ImageRef>& corners, int barrier)
     {
 	const int w = I.size().x;
-	const int stride = 3*w;
+	const int stride = I.row_stride();
 	typedef std::list<const byte*> Passed;
 	Passed passed;
     

--- a/cvd_src/SSE2/faster_corner_9.cxx
+++ b/cvd_src/SSE2/faster_corner_9.cxx
@@ -18,8 +18,8 @@ namespace CVD
     template <bool Aligned> void faster_corner_detect_9(const BasicImage<byte>& I, std::vector<ImageRef>& corners, const int barrier)
     {
 	const int w = I.size().x;
-	const int stride = 3*w;
  
+	const int stride = I.row_stride();
 	const __m128i barriers = _mm_set1_epi8((byte)barrier);
 
 	int xend = I.size().x - 3;


### PR DESCRIPTION
Hi, @edrosten, Thanks for your great library! :+1: 

Please, take a look at these two commits: one is a minor fix to `-Wshadow` warnings, but the important one is the fix to what seems a bug in the SSE2 code for faster. 
The bug would reveal only if width!=stride, which might explain it went unnoticed (?). However, I can't explain the `3` in `3*w` for grayscale images, so I set it to `row_stride()` anyway.
