### PR TITLE
Fix path to sub-files in CVDConfig.cmake

### DIFF
--- a/cmake/CVDConfig.cmake
+++ b/cmake/CVDConfig.cmake
@@ -16,7 +16,7 @@
 #   CVD_FOUND          - True if CVD found.
 
 
-include(CVDFindAllDeps.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/CVDFindAllDeps.cmake)
 
 
 find_path(CVD_INCLUDE_DIR NAMES cvd/config.h PATH_SUFFIXES include)


### PR DESCRIPTION
`CVDConfig.cmake` does not specify an explicit path to `CVDFindAllDeps.cmake`, which means the latter cannot be found when installed. This change fixes the path in the same way as other references in the project.