### PR TITLE
Correct library name to match autoconf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ configure_file(cmake/config.h.in include/cvd/config.h)
 configure_file(cmake/config_internal.h.in include/cvd_src/config_internal.h)
 
 add_library(${PROJECT_NAME} ${SRCS} ${HEADERS})
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME cvd)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/include" ${CVD_DEP_INCLUDES_PUBLIC} PRIVATE ${CVD_DEP_INCLUDES_PRIVATE})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CVD_DEP_LIBS})


### PR DESCRIPTION
The CMake build currently generates `libCVD.a` et al. This case doesn't match the CMake config files or the `autoconf`-generated build. This change changes the output library name to `libcvd`.