### PR TITLE
Fix up exceptions to derive from runtime_error

### DIFF
--- a/cvd/Linux/dvbuffer3.h
+++ b/cvd/Linux/dvbuffer3.h
@@ -18,10 +18,9 @@ namespace CVD
       /// @ingroup gException
       struct All : public CVD::Exceptions::VideoBuffer::All 
       {
-	All(std::string sWhat)
-	  {
-	    what = "DVBuffer3: " + sWhat;
-	  }
+        All(std::string sWhat) : CVD::Exceptions::VideoBuffer::All("DVBuffer3: " + sWhat)
+        {
+        }
       };
     }
   }

--- a/cvd/convolution.h
+++ b/cvd/convolution.h
@@ -99,15 +99,15 @@ namespace Exceptions {
     namespace Convolution {
         /// Base class for all Image_IO exceptions
         /// @ingroup gException
-        struct All: public CVD::Exceptions::All {};
+        struct All: public CVD::Exceptions::All { using CVD::Exceptions::All::All; };
 
         /// Input images have incompatible dimensions
         /// @ingroup gException
         struct IncompatibleImageSizes : public All {
             IncompatibleImageSizes(const std::string & function)
+              : All("Incompatible image sizes in " + function)
             {
-                what = "Incompatible image sizes in " + function;
-	    }
+	          }
 	};
 
 				
@@ -115,8 +115,8 @@ namespace Exceptions {
         /// @ingroup gException
         struct OddSizedKernelRequired : public All {
             OddSizedKernelRequired(const std::string & function)
+              : All("Odd sized kernel required in " + function)
             {
-                what = "Odd sized kernel required in " + function;
             };
         };
     }

--- a/cvd/deinterlacebuffer.h
+++ b/cvd/deinterlacebuffer.h
@@ -21,7 +21,7 @@ namespace Exceptions
 	{	
 		/// Base class for all DeinterlaceBuffer exceptions
 		/// @ingroup gException
-		struct All: public CVD::Exceptions::VideoBuffer::All { }; 
+		struct All: public CVD::Exceptions::VideoBuffer::All { using CVD::Exceptions::VideoBuffer::All::All; }; 
 		
 		/// The VideoBuffer that is being wrapped does not have an even number of lines (so the odd and even- fields would not be the same size)
 		/// @ingroup gException

--- a/cvd/diskbuffer2.h
+++ b/cvd/diskbuffer2.h
@@ -31,7 +31,7 @@ namespace CVD
 		{
 			/// Base class for all DiskBuffer2 exceptions
 			/// @ingroup gException
-			struct All: public CVD::Exceptions::VideoBuffer::All { };
+			struct All: public CVD::Exceptions::VideoBuffer::All { using CVD::Exceptions::VideoBuffer::All::All; };
 			/// An empty list of filename strings was passed to the buffer
 			/// @ingroup gException
 			struct NoFiles: public All { NoFiles(); };
@@ -139,7 +139,7 @@ namespace CVD
 		}
 		catch(Exceptions::Image_IO::All err)
 		{
-			throw Exceptions::DiskBuffer2::BadImage(names[0], err.what);
+			throw Exceptions::DiskBuffer2::BadImage(names[0], err.what());
 		}
 
 		my_size = foo.size();

--- a/cvd/draw.h
+++ b/cvd/draw.h
@@ -28,14 +28,14 @@ namespace Exceptions {
     namespace Draw {
         /// Base class for all Image_IO exceptions
         /// @ingroup gException
-        struct All: public CVD::Exceptions::All {};
+        struct All: public CVD::Exceptions::All { using CVD::Exceptions::All::All; };
 
         /// Input ImageRef not within image dimensions
         /// @ingroup gException
         struct ImageRefNotInImage : public All {
             ImageRefNotInImage(const std::string & function)
+                : All("Input ImageRefs not in image in " + function)
             {
-                what = "Input ImageRefs not in image in " + function;
             };
         };
 
@@ -43,8 +43,8 @@ namespace Exceptions {
         /// @ingroup gException
         struct IncompatibleImageSizes : public All {
             IncompatibleImageSizes(const std::string & function)
+                : All("Incompatible image sizes in " + function)
             {
-                what = "Incompatible image sizes in " + function;
             };
         };
     };

--- a/cvd/esm.h
+++ b/cvd/esm.h
@@ -9,6 +9,7 @@
 #include <cvd/vector_image_ref.h>
 #include <cvd/vision.h>
 
+#include <algorithm>
 #include <vector>
 #include <sstream>
 #include <iomanip>

--- a/cvd/exceptions.h
+++ b/cvd/exceptions.h
@@ -1,7 +1,7 @@
 #ifndef CVD_EXCEPTIONS_H
 #define CVD_EXCEPTIONS_H
 
-#include <string>
+#include <stdexcept>
 
 
 namespace CVD
@@ -13,9 +13,10 @@ namespace CVD
 	{
 		/// Base class for all CVD exceptions 
 		/// @ingroup gException
-		struct All
+		struct All : public std::runtime_error
 		{
-			std::string what; ///< The error message
+			using std::runtime_error::runtime_error;
+			All() : std::runtime_error("No exception message provided") {}
 		};
 
 		/// Out of memory exception

--- a/cvd/haar.h
+++ b/cvd/haar.h
@@ -1,6 +1,7 @@
 #ifndef CVD_HAAR_H
 #define CVD_HAAR_H
 
+#include <algorithm>
 #include <vector>
 #include <cmath>
 #include <cvd/image.h>

--- a/cvd/image.h
+++ b/cvd/image.h
@@ -30,14 +30,14 @@ namespace Exceptions {
   namespace Image {
       /// Base class for all Image_IO exceptions
         /// @ingroup gException
-        struct All: public CVD::Exceptions::All {};
+        struct All: public CVD::Exceptions::All { using CVD::Exceptions::All::All; };
 
         /// Input images have incompatible dimensions
         /// @ingroup gException
         struct IncompatibleImageSizes : public All {
             IncompatibleImageSizes(const std::string & function)
+                : All("Incompatible image sizes in " + function)
             {
-                what = "Incompatible image sizes in " + function;
             };
         };
 
@@ -45,8 +45,8 @@ namespace Exceptions {
         /// @ingroup gException
         struct ImageRefNotInImage : public All {
             ImageRefNotInImage(const std::string & function)
+                : All("Input ImageRefs not in image in " + function)
             {
-                what = "Input ImageRefs not in image in " + function;
             };
         };
     }

--- a/cvd/internal/load_and_save.h
+++ b/cvd/internal/load_and_save.h
@@ -24,7 +24,9 @@ namespace CVD {
 			/// Base class for all Image_IO exceptions
 			/// @ingroup gException
 			struct All: public CVD::Exceptions::All
-			{};
+			{
+				using CVD::Exceptions::All::All;
+			};
 
 			/// This image type is not supported
 			/// @ingroup gException

--- a/cvd/morphology.h
+++ b/cvd/morphology.h
@@ -4,6 +4,7 @@
 #include <cvd/vision_exceptions.h>
 #include <cvd/vision.h>
 #include <cvd/image.h>
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <vector>

--- a/cvd/timeddiskbuffer.h
+++ b/cvd/timeddiskbuffer.h
@@ -13,7 +13,7 @@ namespace CVD {
 		{
 			/// Base class for all DiskBuffer2 exceptions
 			/// @ingroup gException
-			struct All: public CVD::Exceptions::VideoBuffer::All { };
+			struct All: public CVD::Exceptions::VideoBuffer::All { using CVD::Exceptions::VideoBuffer::All::All; };
 			/// list lengths for name and time lists do not agree
 			/// @ingroup gException
 			struct IncompatibleListLengths: public All { IncompatibleListLengths(); };

--- a/cvd/videobuffer.h
+++ b/cvd/videobuffer.h
@@ -153,6 +153,7 @@ namespace Exceptions
 		/// @ingroup gException
 		struct All: public CVD::Exceptions::All
 		{
+			using CVD::Exceptions::All::All;
 		};
 
 		/// The VideoBuffer was unable to successfully complete a VideoBuffer::put_frame() operation

--- a/cvd/videofilebuffer.h
+++ b/cvd/videofilebuffer.h
@@ -27,7 +27,7 @@ namespace CVD
 		{
 			/// Base class for all VideoFileBuffer exceptions
 			/// @ingroup gException
-			struct All: public CVD::Exceptions::VideoBuffer::All { };
+			struct All: public CVD::Exceptions::VideoBuffer::All { using CVD::Exceptions::VideoBuffer::All::All; };
 			/// Unable to open the file as a video stream, for various reasons
 			/// @ingroup gException
 			struct FileOpen: public All { FileOpen(const std::string& file, const std::string& error); ///< Construt from filename and error message

--- a/cvd/videosource.h
+++ b/cvd/videosource.h
@@ -327,7 +327,6 @@ namespace CVD {
 
 	template <class T> VideoBuffer<T>* open_video_source(const VideoSource& vs)
 	{
-		using std::auto_ptr;
 		if(vs.protocol == "jpegstream")
 		{
 			int ra_frames=0;

--- a/cvd/videosource.h
+++ b/cvd/videosource.h
@@ -25,12 +25,12 @@
 namespace CVD {
 	struct ParseException : public Exceptions::All
 	{
-		ParseException(const std::string& what_) { what = what_; }
+		ParseException(const std::string& what_) : Exceptions::All(what_) {}
 	};
 	
 	struct VideoSourceException : public Exceptions::All
 	{
-		VideoSourceException(const std::string& what_) { what = what_; }
+		VideoSourceException(const std::string& what_) : Exceptions::All(what_) {}
 	};
 
 	struct VideoSource 

--- a/cvd/vision_exceptions.h
+++ b/cvd/vision_exceptions.h
@@ -2,6 +2,7 @@
 #define CVD_INCLUDE_VISION_EXCEPTIONS_H
 
 #include <cvd/exceptions.h>
+#include <string>
 
 namespace CVD {
 
@@ -12,14 +13,14 @@ namespace CVD {
 		namespace Vision {
 			/// Base class for all Image_IO exceptions
 			/// @ingroup gException
-			struct All: public CVD::Exceptions::All {};
+			struct All: public CVD::Exceptions::All { using CVD::Exceptions::All::All; };
 
 			/// Input images have incompatible dimensions
 			/// @ingroup gException
 			struct IncompatibleImageSizes : public All {
 				IncompatibleImageSizes(const std::string & function)
+					: All("Incompatible image sizes in " + function)
 				{
-					what = "Incompatible image sizes in " + function;
 				};
 			};
 
@@ -27,16 +28,16 @@ namespace CVD {
 			/// @ingroup gException
 			struct ImageRefNotInImage : public All {
 				ImageRefNotInImage(const std::string & function)
+					: All("Input ImageRefs not in image in " + function)
 				{
-					what = "Input ImageRefs not in image in " + function;
 				};
 			};
 
 
 			struct BadInput: public All{
 				BadInput(const std::string& function)
+					: All("Bad input in " + function)
 				{
-					what = "Bad input in " + function;
 				};
 			};
 		};

--- a/cvd_src/Linux/dvbuffer.cc
+++ b/cvd_src/Linux/dvbuffer.cc
@@ -110,31 +110,32 @@ using namespace std;
 namespace CVD
 {
 Exceptions::DVBuffer::DeviceOpen::DeviceOpen(string name)
+  : All("DVBuffer2 couldn't open " + name + ": "+ strerror(errno))
 {
-	what = "DVBuffer2 couldn't open " + name + ": "+ strerror(errno);
 }
 
 Exceptions::DVBuffer::Raw1394Setup::Raw1394Setup(string action)
+  : All("DVBuffer2 (in Raw1394 setup): " + action + ": " + strerror(errno))
 {
-	what = "DVBuffer2 (in Raw1394 setup): " + action + ": " + strerror(errno);
 }
 
 Exceptions::DVBuffer::DC1394Setup::DC1394Setup(string action)
+  : All("DVBuffer2 (in camera setup): " + action)
 {
-	what = "DVBuffer2 (in camera setup): " + action;// + ": " + strerror(errno);
 }
 
 Exceptions::DVBuffer::BadCameraSelection::BadCameraSelection(int nc, int cn)
+  : All([=]()
+  {
+    ostringstream o;
+    o << "DVBuffer2: Camera number " << cn << " requested, but there are only " << nc << " cameras plugged in.";
+    return o.str();
+  })
 {
-	ostringstream o;
-	o << "DVBuffer2: Camera number " << cn << " requested, but there are only " << nc << " cameras plugged in.";
-	what = o.str();
 }
 
 Exceptions::DVBuffer::BusReset::BusReset()
-{
-
-  what =     "Sorry, your RawDCVideo is the highest numbered node\n"
+  : All(     "Sorry, your RawDCVideo is the highest numbered node\n"
              "of the bus, and has therefore become the root node.\n"
              "The root node is responsible for maintaining \n"
              "the timing of isochronous transactions on the IEEE \n"
@@ -151,12 +152,14 @@ Exceptions::DVBuffer::BusReset::BusReset()
              "   insmod ohci1394 attempt_root=1\n"
              "\n"
 			 "A quicker solution is to unplug the camera and plug it back in again.\n"
-             "\n";
+             "\n"
+  )
+{
 }
 
 Exceptions::DVBuffer::DeviceSetup::DeviceSetup(string action)
+  : All("DVBuffer2 (in setup): Failed on " + action + ": " + strerror(errno))
 {
-  what = "DVBuffer2 (in setup): Failed on " + action + ": " + strerror(errno);
 }
 
 namespace DC

--- a/cvd_src/Linux/v4lbuffer.cc
+++ b/cvd_src/Linux/v4lbuffer.cc
@@ -14,28 +14,28 @@ using namespace std;
 namespace CVD { // CVD
 
 Exceptions::V4LBuffer::DeviceOpen::DeviceOpen(string device)
+	: All("V4LBuffer: failed to open \""+device+ "\": " + strerror(errno))
 {
-	what = "V4LBuffer: failed to open \""+device+ "\": " + strerror(errno);
 }
 
 Exceptions::V4LBuffer::DeviceSetup::DeviceSetup(string device, string action)
+	: All("V4LBuffer: \""+action + "\" ioctl failed on " + device + ": " +strerror(errno))
 {
-	what = "V4LBuffer: \""+action + "\" ioctl failed on " + device + ": " +strerror(errno);
 }
 
 Exceptions::V4LBuffer::PutFrame::PutFrame(string device, string msg)
+	: All("V4LBuffer: PutFrame on " + device + " failed: " + msg)
 {
-	what = "V4LBuffer: PutFrame on " + device + " failed: " + msg;
 }
 
 Exceptions::V4LBuffer::GetFrame::GetFrame(string device, string msg)
+	: All("V4LBuffer: GetFrame on " + device + " failed: " + msg)
 {
-	what = "V4LBuffer: GetFrame on " + device + " failed: " + msg;
 }
 
 Exceptions::V4LBuffer::NoColourspace::NoColourspace(std::string dev, std::string space)
+	: All("V4LBuffer: No colourspace  on " + dev + " matching " + space)
 {
-	what = "V4LBuffer: No colourspace  on " + dev + " matching " + space;
 }
 
 

--- a/cvd_src/Linux/v4lcontrol.cc
+++ b/cvd_src/Linux/v4lcontrol.cc
@@ -27,35 +27,38 @@ static inline T fromUnit( double val, T min, T max){
 namespace CVD {
 
 Exceptions::V4LControl::DeviceOpen::DeviceOpen(string device)
+    : All("V4LControl: failed to open \""+device+ "\": " + strerror(errno))
 {
-    what = "V4LControl: failed to open \""+device+ "\": " + strerror(errno);
 }
 
 Exceptions::V4LControl::ParameterNotSupported::ParameterNotSupported(string parameter)
+    : All("V4LControl: parameter \"" + parameter + "\" is not supported.")
 {
-    what = "V4LControl: parameter \"" + parameter + "\" is not supported.";
 }
 
 Exceptions::V4LControl::ParameterNotSupported::ParameterNotSupported(unsigned int id)
+    : All([=]()
+    {
+        ostringstream os;
+        os << "V4LControl: parameter " << id << " is not supported.";
+        return os.str();
+    })
 {
-    ostringstream os;
-    os << "V4LControl: parameter " << id << " is not supported.";
-    what = os.str();
 }
 
 Exceptions::V4LControl::GetValue::GetValue(string parameter)
+    : All("V4LControl: query value \""+parameter+ "\" failed: " + strerror(errno))
 {
-    what = "V4LControl: query value \""+parameter+ "\" failed: " + strerror(errno);
 }
 
 Exceptions::V4LControl::SetValue::SetValue(string parameter)
+    : All("V4LControl: setting value \""+parameter+ "\" failed: " + strerror(errno))
 {
-    what = "V4LControl: setting value \""+parameter+ "\" failed: " + strerror(errno);
 }
 
 Exceptions::V4LControl::QueryParameters::QueryParameters(string msg)
+    : All("V4LControl: Querying parameters failed: \""+msg+ "\": " + strerror(errno))
 {
-    what = "V4LControl: Querying parameters failed: \""+msg+ "\": " + strerror(errno);
 }
 
 V4LControl::V4LControl( int fd, bool report ) : device(fd), deviceName(""), reportErrors(report) {

--- a/cvd_src/SSE/convolve_gaussian.cc
+++ b/cvd_src/SSE/convolve_gaussian.cc
@@ -1,4 +1,5 @@
 #include <cvd/convolution.h>
+#include <algorithm>
 #include <xmmintrin.h>
 
 using namespace std;

--- a/cvd_src/convolution.cc
+++ b/cvd_src/convolution.cc
@@ -1,4 +1,5 @@
 #include "cvd/convolution.h"
+#include <algorithm>
 #include <cmath>
 using namespace std;
 

--- a/cvd_src/deinterlacebuffer.cc
+++ b/cvd_src/deinterlacebuffer.cc
@@ -8,6 +8,6 @@ using namespace CVD:: Exceptions:: DeinterlaceBuffer;
 
 
 OddNumberOfLines::OddNumberOfLines()
+	: CVD::Exceptions::DeinterlaceBuffer::All("VideoFrame passed to DeinterlaceBuffer has an odd number of lines!")
 {
-	what = "VideoFrame passed to DeinterlaceBuffer has an odd number of lines!";
 }

--- a/cvd_src/diskbuffer2.cc
+++ b/cvd_src/diskbuffer2.cc
@@ -8,34 +8,35 @@ using namespace CVD::Exceptions;
 using namespace std;
 
 
-DiskBuffer2::NoFiles::NoFiles()
+DiskBuffer2::NoFiles::NoFiles() : All("DiskBuffer2 has an empty list of files.")
 {
-	what = "DiskBuffer2 has an empty list of files.";
 }
 
 DiskBuffer2::BadImageSize::BadImageSize(const std::string& name)
+	: All("DiskBuffer2: Image \"" + name + "\" does not match diskbuffer size.")
 {
-	what = "DiskBuffer2: Image \"" + name + "\" does not match diskbuffer size.";
 }
 
 DiskBuffer2::BadFile::BadFile(const std::string& name, int err)
+	: All("DiskBuffer2: File open on \""+name+"\" failed with " + strerror(err))
 {
-	what="DiskBuffer2: File open on \""+name+"\" failed with " + strerror(err);
 }
 
 DiskBuffer2::BadImage::BadImage(const std::string& file, const std::string & error)
+	: All("DiskBuffer2: File \""+file+"\" load failed: " + error)
 {
-	what="DiskBuffer2: File \""+file+"\" load failed: " + error;
 }
 
 DiskBuffer2::EndOfBuffer::EndOfBuffer()
+	: All("DiskBuffer2 has reached the end of its list of files")
 {
-	what="DiskBuffer2 has reached the end of its list of files";
 }
 
 DiskBuffer2::BadSeek::BadSeek(double t)
+	: All([=] {
+		ostringstream ss;
+		ss << "DiskBuffer2: Seek to time " << t << "mS failed. No such time in the buffer";
+		return ss.str();
+	}())
 {
-	ostringstream ss;
-	ss << "DiskBuffer2: Seek to time " << t << "mS failed. No such time in the buffer";
-	what = ss.str();
 }

--- a/cvd_src/exceptions.cc
+++ b/cvd_src/exceptions.cc
@@ -1,17 +1,17 @@
 #include <cvd/exceptions.h>
 #include <cvd/videobuffer.h>
 
-CVD::Exceptions::OutOfMemory::OutOfMemory()
+CVD::Exceptions::OutOfMemory::OutOfMemory() : CVD::Exceptions::All("Out of memory.")
 {
-	what="Out of memory.";
 }
 
 CVD::Exceptions::VideoBuffer::BadPutFrame::BadPutFrame()
-{	
-	what="Attempted to put_frame() on the wrong kind of frame.";
+	: CVD::Exceptions::VideoBuffer::All("Attempted to put_frame() on the wrong kind of frame.")
+{
 }
 
 CVD::Exceptions::VideoBuffer::BadColourSpace::BadColourSpace(const std::string& c, const std::string& buffer)
-{	
-	what=buffer + " can not grab video in the " + c + "colourspace on the specified device.";
+	: CVD::Exceptions::VideoBuffer::All(
+		buffer + " can not grab video in the " + c + "colourspace on the specified device.")
+{
 }

--- a/cvd_src/image_io.cc
+++ b/cvd_src/image_io.cc
@@ -10,73 +10,76 @@ using namespace std;
 namespace CVD{
 
 Exceptions::Image_IO::ImageSizeMismatch::ImageSizeMismatch(const ImageRef& src, const ImageRef& dest)
-{
-	ostringstream o;
-	o <<
-"Image load: Size mismatch when loading an image (size " << src << ") in to a non\
-resizable image (size " << dest << ").";
+	: All([=]() {
+		ostringstream o;
+		o <<
+	"Image load: Size mismatch when loading an image (size " << src << ") in to a non\
+	resizable image (size " << dest << ").";
 
-	what = o.str();
+		return o.str();
+	}())
+{
 }
 
 Exceptions::Image_IO::OpenError::OpenError(const string& name, const string& why, int error)
+	: All("Opening file: " + name+ " (" + why + "): " + strerror(error))
 {
-	what = "Opening file: " + name+ " (" + why + "): " + strerror(error);
 }
 
 Exceptions::Image_IO::MalformedImage::MalformedImage(const string& why)
+	: All("Image input: " + why)
 {
-	what = "Image input: " + why;
 }
 
 Exceptions::Image_IO::UnsupportedImageType::UnsupportedImageType()
+	: All("Image input: Unsuppported image type.")
 {
-	what = "Image input: Unsuppported image type.";
 }
 
 Exceptions::Image_IO::IfstreamNotOpen::IfstreamNotOpen()
+	: All("Image input: File stream has not been opened succesfully.")
 {
-	what = "Image input: File stream has not been opened succesfully.";
 }
 
 Exceptions::Image_IO::EofBeforeImage::EofBeforeImage()
+	: All("Image input: End of file occured before image.")
 {
-	what = "Image input: End of file occured before image.";
 }
 
 Exceptions::Image_IO::WriteError::WriteError(const string& s)
+	: All("Error writing " + s)
 {
-	what = "Error writing " + s;
 }
 
 Exceptions::Image_IO::WriteTypeMismatch::WriteTypeMismatch(const string& avail, const string& req)
+	: All("Image output (CVD internal error): Attempting to write " + req + " data to a file containing " + avail)
 {
-	what = "Image output (CVD internal error): Attempting to write " + req + " data to a file containing " + avail;
 }
 
 Exceptions::Image_IO::ReadTypeMismatch::ReadTypeMismatch(const string& avail, const string& req)
+	: All("Image input (CVD internal error): Attempting to read " + req + " data from a file containing " + avail)
 {
-	what = "Image input (CVD internal error): Attempting to read " + req + " data from a file containing " + avail;
 }
 
 Exceptions::Image_IO::ReadTypeMismatch::ReadTypeMismatch(const bool read8)
+	: All(string("Image input (CVD internal error): Attempting to read ") +
+		  (read8?"8":"16") + "bit data from " + (read8?"16":"8")  + "bit file (probably an internal error).")
 {
-	what = string("Image input (CVD internal error): Attempting to read ") + (read8?"8":"16") + "bit data from " + (read8?"16":"8")  + "bit file (probably an internal error).";
 }
 
 Exceptions::Image_IO::UnseekableIstream::UnseekableIstream(const string& s)
+	: All("Image input: Loading " + s + " images requires seekable istream.")
 {
-	what = "Image input: Loading " + s + " images requires seekable istream.";
 }
 
 Exceptions::Image_IO::UnsupportedImageSubType::UnsupportedImageSubType(const string& i, const string& why)
+	: All("Image input: Unsupported subtype of " + i+ " image: " + why)
 {
-	what = "Image input: Unsupported subtype of " + i+ " image: " + why;
 }
 
 Exceptions::Image_IO::InternalLibraryError::InternalLibraryError(const std::string& l, const std::string e)
+	: All("Internal error in " + l + " library: " + e)
 {
-	what = "Internal error in " + l + " library: " + e;
 }
 
 ImageType::ImageType string_to_image_type(const std::string& name)

--- a/cvd_src/timeddiskbuffer.cc
+++ b/cvd_src/timeddiskbuffer.cc
@@ -1,6 +1,6 @@
 #include <cvd/timeddiskbuffer.h>
 
 CVD::Exceptions::TimedDiskBuffer::IncompatibleListLengths::IncompatibleListLengths()
+	: All("TimedDiskBuffer received file and timestamp lists of different lengths.")
 {
-	what = "TimedDiskBuffer received file and timestamp lists of different lengths.";
 }

--- a/cvd_src/uvcbuffer.cc
+++ b/cvd_src/uvcbuffer.cc
@@ -6,43 +6,43 @@ namespace CVD{
 
 namespace Exceptions{ namespace UVCBuffer{
 	Init::Init(string, string err)
+		: All("UVCBuffer: failed to initialize: " + err)
 	{
-		what = "UVCBuffer: failed to initialize: " + err;
 	}
 
 
 	DeviceOpen::DeviceOpen(string dev, string err)
+		: All("UVCBuffer: failed to open \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed to open \"" + dev + "\": "  + err;
 	}
 
 	FindDevice::FindDevice(string dev, string err)
+		: All("UVCBuffer: failed to find device \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed to find device \"" + dev + "\": "  + err;
 	}
 
 	DeviceSetup::DeviceSetup(string dev, string err)
+		: All("UVCBuffer: failed to setup device \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed to setup device \"" + dev + "\": "  + err;
 	}
 
 	GetFrame::GetFrame(string dev, string err)
+		: All("UVCBuffer: failed to get frame on \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed to get frame on \"" + dev + "\": "  + err;
 	}
 
 	PutFrame::PutFrame(string dev, string err)
+		: All("UVCBuffer: failed to put frame on \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed to put frame on \"" + dev + "\": "  + err;
 	}
 
 	StreamOpen::StreamOpen(string dev, string err)
+		: All("UVCBuffer: failed open stream on \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed open stream on \"" + dev + "\": "  + err;
 	}
 	StreamStart::StreamStart(string dev, string err)
+		: All("UVCBuffer: failed start stream on \"" + dev + "\": "  + err)
 	{
-		what = "UVCBuffer: failed start stream on \"" + dev + "\": "  + err;
 	}
 }}
 

--- a/cvd_src/videofilebuffer2.cc
+++ b/cvd_src/videofilebuffer2.cc
@@ -58,12 +58,9 @@ namespace CVD{
 
 namespace Exceptions
 {
-	struct VideoFileBuffer2
+	struct VideoFileBuffer2 : CVD::Exceptions::VideoBuffer::All
 	{
-		string what;
-		VideoFileBuffer2(string s_)
-		:what(s_)
-		{}
+		using CVD::Exceptions::VideoBuffer::All::All;
 	};
 }
 

--- a/cvd_src/videofilebuffer_exceptions.cc
+++ b/cvd_src/videofilebuffer_exceptions.cc
@@ -13,44 +13,50 @@ using namespace Exceptions::VideoFileBuffer;
 //
 
 Exceptions::VideoFileBuffer::FileOpen::FileOpen(const std::string& name, const string& error)
+	: All("RawVideoFileBuffer: Error opening file \"" + name + "\": " + error)
 {
-	what = "RawVideoFileBuffer: Error opening file \"" + name + "\": " + error;
 }
 
 Exceptions::VideoFileBuffer::BadFrameAlloc::BadFrameAlloc()
+	: All("RawVideoFileBuffer: Unable to allocate video frame.")
 {
-	what = "RawVideoFileBuffer: Unable to allocate video frame.";
 }
 
 Exceptions::VideoFileBuffer::BadDecode::BadDecode(double t, const string& s)
+	: All([=]()
+	{
+		ostringstream os;
+		os << "RawVideoFileBuffer: Error decoding video frame at time " << t;
+		
+		if(s == "")
+			os 	<< ".";
+		else
+			os << ": " << s;
+		return os.str();
+	}())
 {
-	ostringstream os;
-	os << "RawVideoFileBuffer: Error decoding video frame at time " << t;
-	
-	if(s == "")
-		os 	<< ".";
-	else
-		os << ": " << s;
-	what = os.str();
 }
 
 Exceptions::VideoFileBuffer::EndOfFile::EndOfFile()
+	: All("RawVideoFileBuffer: Tried to read off the end of the file.")
 {
-	what =  "RawVideoFileBuffer: Tried to read off the end of the file.";
 }
 
 Exceptions::VideoFileBuffer::BadSeek::BadSeek(double t, const string& s)
+	: All([=]()
+	{
+		ostringstream os;
+		os << "RawVideoFileBuffer: Seek to time " << t << "s failed";
+
+		
+		if(s == "")
+			os 	<< ".";
+		else
+			os << ": " << s;
+
+		return os.str();
+	}())
 {
-	ostringstream os;
-	os << "RawVideoFileBuffer: Seek to time " << t << "s failed";
-
-	
-	if(s == "")
-		os 	<< ".";
-	else
-		os << ": " << s;
-
-	what = os.str();
 }
 
 }

--- a/progs/calibrate.cxx
+++ b/progs/calibrate.cxx
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <fstream>

--- a/tests/load_and_save.cc
+++ b/tests/load_and_save.cc
@@ -203,7 +203,7 @@ template<class T> void loadsave_safe(const char*n)
 	}
 	catch(CVD::Exceptions::All b0rk3d)
 	{
-		cerr << "Image " << n << " error: " << b0rk3d.what << endl;
+		cerr << "Image " << n << " error: " << b0rk3d.what() << endl;
 	}
 }
 
@@ -277,7 +277,7 @@ template<class T> struct randtest
 			}
 			catch(Exceptions::All w)
 			{
-				cerr << w.what << endl;
+				cerr << w.what() << endl;
 			}
 		}
 


### PR DESCRIPTION
Exceptions in `libcvd` do not derive from `std::exception`, and the CVD exception hierarchy is inconsistently used. This change makes the CVD exception hierarchy derive from `std::runtime_error`, and fixes up an exception that does not derive correctly.

This change also fixes up a couple of conformance issues necessary to use this correctly on modern compilers.