### PR TITLE
Make Rgba initialize like Rgb

### DIFF
--- a/cvd/rgba.h
+++ b/cvd/rgba.h
@@ -17,8 +17,9 @@ template <typename T>
 class Rgba
 {
 public:
-	/// Default constructor. Sets everything to 0.
-	explicit Rgba() : red(0), green(0), blue(0), alpha(0) {}
+	Rgba() = default;
+	Rgba(const Rgba&) = default;
+	Rgba& operator=(const Rgba&) = default;
 
 	/// Constructs a colour as specified
 	/// @param r The red component


### PR DESCRIPTION
https://github.com/edrosten/libcvd/commit/718e263c82bcd5142f678e0d95062438cf6ad84e changed the `Rgb` constructors to defaulted, giving it sensible and performant semantics for default-initialization. This change does the same for `Rgba`. This makes things like `Image<Rgba<T>>::resize` much, much faster.