### PR TITLE
Fix build of GLWindow with new exceptions

### DIFF
--- a/cvd_src/Win32/glwindow.cpp
+++ b/cvd_src/Win32/glwindow.cpp
@@ -13,13 +13,13 @@ using namespace std;
 namespace CVD {
 
 	Exceptions::GLWindow::CreationError::CreationError(std::string w)
+	:CVD::Exceptions::GLWindow::All {"GLWindow creation error: " + w}
 	{
-		what="GLWindow creation error: " + w;
 	}
 
 	Exceptions::GLWindow::RuntimeError::RuntimeError(std::string w)
+	:CVD::Exceptions::GLWindow::All {"GLWindow error: " + w}
 	{
-		what="GLWindow error: " + w;
 	}
 
 	struct GLWindow::State {


### PR DESCRIPTION
The changes to the exception hierarchy in https://github.com/edrosten/libcvd/pull/57 did not update the Windows build. This change updates the `GLWindow` exceptions to build correctly on Windows.