### PR TITLE
FFmpeg 5 compatibility

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - run: |
            sudo apt-get update
-           sudo apt install g++-10 gcc-10 ffmpeg
+           sudo apt install g++-10 gcc-10 libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev libswscale-dev
     - uses: actions/checkout@v2
     - name: configure
       run: ./configure
@@ -28,7 +28,7 @@ jobs:
     steps:
     - run: |
            sudo apt-get update
-           sudo apt install g++-10 gcc-10 cmake ffmpeg
+           sudo apt install g++-10 gcc-10 cmake libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev libswscale-dev
     - uses: actions/checkout@v2
     - name: setup
       run: mkdir build

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - run: |
            sudo apt-get update
-           sudo apt install g++-10 gcc-10
+           sudo apt install g++-10 gcc-10 ffmpeg
     - uses: actions/checkout@v2
     - name: configure
       run: ./configure
@@ -28,7 +28,7 @@ jobs:
     steps:
     - run: |
            sudo apt-get update
-           sudo apt install g++-10 gcc-10 cmake
+           sudo apt install g++-10 gcc-10 cmake ffmpeg
     - uses: actions/checkout@v2
     - name: setup
       run: mkdir build

--- a/cvd/videofilebuffer.h
+++ b/cvd/videofilebuffer.h
@@ -127,9 +127,6 @@ namespace VFB
 		/// What is the path to the video file?
 		std::string file_name();
 
-		/// What codec is being used to decode this video?
-		std::string codec_name();
-
 		private:
 		std::unique_ptr<RawVideoFileBufferPIMPL> p;
 	};
@@ -218,12 +215,6 @@ class VideoFileBuffer : public CVD::LocalVideoBuffer<T>
 	std::string file_name()
 	{
 		return vf.file_name();
-	}
-
-	/// What codec is being used to decode this video?
-	std::string codec_name()
-	{
-		return vf.codec_name();
 	}
 
 	private:

--- a/cvd_src/videofilebuffer2.cc
+++ b/cvd_src/videofilebuffer2.cc
@@ -284,9 +284,7 @@ namespace VFB
 				if(input_format_context == NULL)
 					throw Exceptions::VideoFileBuffer2("Out of memory.");
 
-				const AVInputFormat* fmt = nullptr;
-				if(formatname != "")
-					fmt = av_find_input_format(formatname.c_str());
+				auto* fmt = (formatname != "") ? av_find_input_format(formatname.c_str()) : nullptr;
 
 				VS("av_find_input_format(" << formatname << ") = " << fmt);
 				if(fmt != nullptr)


### PR DESCRIPTION
This change updates `VideoFileBuffer` to support newer versions of FFmpeg. This supports FFmpeg between v3 and v5, which requires a version check to avoid calling deprecated register functions.

This change also adds `ffmpeg` to the CI build to test builds in CI.