### PR TITLE
Add video writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ if(CVD_FFMPEG_FOUND)
 		cvd_src/videoreader.cc
 		cvd_src/videoreaderfilebuffer.cc
 		cvd_src/videoscaler.cc
+		cvd_src/videowriter.cc
 		cvd_src/videofilebuffer2.cc
 		cvd_src/videosource_videofilebuffer.cc)
 	list(APPEND HEADERS
@@ -248,6 +249,7 @@ if(CVD_FFMPEG_FOUND)
 		cvd/videoreader.h
 		cvd/videoreaderfilebuffer.h
 		cvd/videoscaler.h
+		cvd/videowriter.h
 	)
 else()
 	set(CVD_HAVE_FFMPEG OFF)

--- a/configure
+++ b/configure
@@ -10322,6 +10322,7 @@ then
 	dep_objects="$dep_objects cvd_src/videoreader.o"
 	dep_objects="$dep_objects cvd_src/videoreaderfilebuffer.o"
 	dep_objects="$dep_objects cvd_src/videoscaler.o"
+	dep_objects="$dep_objects cvd_src/videowriter.o"
 else
 	dep_objects="$dep_objects cvd_src/videosource_novideofilebuffer.o"
 fi
@@ -10414,6 +10415,7 @@ progs=$progs
 if test "$have_ffmpeg" == yes
 then
 	testprogs="$testprogs videoreader_test"
+	testprogs="$testprogs videowriter_test"
 fi
 
 testprogs=$testprogs

--- a/configure.ac
+++ b/configure.ac
@@ -633,6 +633,7 @@ then
 	DEPOBJ(videoreader)
 	DEPOBJ(videoreaderfilebuffer)
 	DEPOBJ(videoscaler)
+	DEPOBJ(videowriter)
 else
 	DEPOBJ(videosource_novideofilebuffer)
 fi
@@ -723,6 +724,7 @@ define(DEPTEST, [APPEND(testprogs, $1)])
 if test "$have_ffmpeg" == yes
 then 
 	DEPTEST(videoreader_test)
+	DEPTEST(videowriter_test)
 fi
 
 AC_SUBST(testprogs, [$testprogs])

--- a/cvd/videowriter.h
+++ b/cvd/videowriter.h
@@ -1,0 +1,57 @@
+#ifndef LIBCVD_VIDEOWRITER_H
+#define LIBCVD_VIDEOWRITER_H
+
+#include "image.h"
+#include "rgba.h"
+#include "videoffmpeg.h"
+
+#include <libavutil/rational.h>
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace CVD
+{
+namespace internal
+{
+	class Scaler;
+}
+
+// Simple video writer to write RGBA frames to a video file.
+class VideoWriter
+{
+	public:
+	VideoWriter(const std::string& filename,
+	    const std::string& codec_name,
+	    const std::string& pixel_format_name,
+	    AVRational timebase,
+	    AVRational frame_rate,
+	    int rotation_degrees,
+	    int threads,
+	    int bitrate = -1,
+	    std::int64_t duration = -1);
+	~VideoWriter();
+
+	std::int64_t seconds_to_timebase(double seconds) const
+	{
+		return static_cast<std::int64_t>(std::round((seconds * m_timebase.den) / m_timebase.num));
+	}
+	void put_frame(const BasicImage<Rgba<std::uint8_t>>& image, std::int64_t pts);
+
+	private:
+	std::string m_filename;
+	AVRational m_timebase;
+	int m_threads;
+	const AVCodec* m_codec;
+	int m_bitrate;
+	std::unique_ptr<AVFormatContext, internal::AVFormatContextCloser> m_format_context;
+	std::unique_ptr<AVCodecContext, internal::AVCodecContextCloser> m_codec_context;
+	std::unique_ptr<internal::Scaler> m_scaler;
+};
+
+}
+
+#endif

--- a/cvd_src/videowriter.cc
+++ b/cvd_src/videowriter.cc
@@ -1,0 +1,212 @@
+#include "cvd/videowriter.h"
+#include "cvd/videoscaler.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libswscale/swscale.h>
+}
+
+namespace CVD
+{
+namespace
+{
+	using std::uint8_t;
+
+	// Calculate the greatest common divisor of two values.
+	int gcd(int a, int b)
+	{
+		if(a < 0)
+			a = -a;
+		if(b < 0)
+			b = -b;
+		for(;;)
+		{
+			if(a == 0)
+				return b;
+			if(b == 0)
+				return a;
+			const int t = b;
+			b = a % b;
+			a = t;
+		}
+	}
+
+	// Multiply one rational number by another.
+	AVRational multiply_rational(const AVRational& left, const AVRational& right)
+	{
+		AVRational r { left.num * right.num, left.den * right.den };
+		if(r.num == 0)
+		{
+			r.den = 1;
+		}
+		else
+		{
+			int d = gcd(r.num, r.den);
+			if(d > 1)
+			{
+				r.num /= d;
+				r.den /= d;
+			}
+		}
+		return r;
+	}
+
+	// Divide one rational number by another.
+	AVRational divide_rational(const AVRational& left, const AVRational& right)
+	{
+		return multiply_rational(left, AVRational { right.den, right.num });
+	}
+
+}
+
+VideoWriter::VideoWriter(const std::string& filename,
+    const std::string& codec_name,
+    const std::string& pixel_format_name,
+    AVRational timebase,
+    AVRational frame_rate,
+    int rotation_degrees,
+    int threads,
+    int bitrate,
+    std::int64_t duration)
+    : m_filename(filename)
+    , m_timebase(timebase)
+    , m_threads(threads)
+    , m_bitrate(bitrate)
+{
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+	// see https://github.com/FFmpeg/FFmpeg/commit/0694d8702421e7aff1340038559c438b61bb30dd
+	av_register_all();
+#endif
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
+	// see https://github.com/FFmpeg/FFmpeg/commit/3f0a41367eb9180ab6d22d43ad42b9bd85a26df0
+	avcodec_register_all();
+#endif
+
+	m_codec = avcodec_find_encoder_by_name(codec_name.c_str());
+	if(!m_codec)
+	{
+		throw std::runtime_error("Unable to find codec");
+	}
+
+	AVFormatContext* format_ptr;
+	internal::CheckAVError(avformat_alloc_output_context2(&format_ptr, nullptr, nullptr, m_filename.c_str()));
+	m_format_context.reset(format_ptr);
+
+	auto stream = avformat_new_stream(m_format_context.get(), nullptr);
+	if(!stream)
+	{
+		throw std::runtime_error("avformat_new_stream");
+	}
+	stream->time_base = timebase;
+	if(codec_name == "mpeg4")
+	{
+		// MPEG-4 standard codec can only handle timebases with 16-bit numerator and denominator.
+		while(stream->time_base.den > 65535)
+		{
+			stream->time_base.den /= 2;
+		}
+		while(stream->time_base.num > 65535)
+		{
+			stream->time_base.num /= 2;
+		}
+	}
+
+	stream->avg_frame_rate = frame_rate;
+	stream->r_frame_rate = frame_rate;
+	if(duration >= 0)
+	{
+		stream->duration = duration;
+	}
+	internal::CheckAVError(av_dict_set(&stream->metadata, "rotate", std::to_string(rotation_degrees).c_str(), 0));
+
+	m_codec_context.reset(avcodec_alloc_context3(m_codec));
+	if(!m_codec_context)
+	{
+		throw std::runtime_error("avcodec_alloc_context3");
+	}
+	m_codec_context->thread_count = threads;
+	m_codec_context->codec_id = m_codec->id;
+	m_codec_context->time_base = stream->time_base;
+	m_codec_context->framerate = frame_rate;
+
+	AVPixelFormat pixel_format = av_get_pix_fmt(pixel_format_name.c_str());
+	if(pixel_format != AV_PIX_FMT_NONE)
+	{
+		m_codec_context->pix_fmt = pixel_format;
+	}
+	else
+	{
+		m_codec_context->pix_fmt = m_codec->pix_fmts ? m_codec->pix_fmts[0] : AV_PIX_FMT_YUV420P;
+	}
+	if(m_format_context->oformat->flags & AVFMT_GLOBALHEADER)
+	{
+		m_codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+	}
+	if(m_bitrate > 0)
+	{
+		m_codec_context->bit_rate = m_bitrate;
+	}
+	m_codec_context->colorspace = AVCOL_SPC_BT709;
+	m_codec_context->color_primaries = AVCOL_PRI_BT709;
+	m_codec_context->color_trc = AVCOL_TRC_BT709;
+	m_codec_context->sample_aspect_ratio = { 1, 1 };
+}
+
+void VideoWriter::put_frame(const BasicImage<Rgba<uint8_t>>& image, std::int64_t pts)
+{
+	if(!m_scaler)
+	{
+		m_codec_context->width = image.size().x;
+		m_codec_context->height = image.size().y;
+
+		auto stream = m_format_context->streams[0];
+
+		AVDictionary* dict = nullptr;
+		internal::CheckAVError(avcodec_open2(m_codec_context.get(), m_codec, &dict));
+		internal::CheckAVError(avcodec_parameters_from_context(stream->codecpar, m_codec_context.get()));
+		internal::CheckAVError(avio_open2(&m_format_context->pb, m_filename.c_str(), AVIO_FLAG_WRITE, nullptr, &dict));
+		internal::CheckAVError(avformat_write_header(m_format_context.get(), &dict));
+		av_dict_free(&dict);
+
+		m_scaler = std::make_unique<internal::Scaler>(
+		    m_codec_context->width,
+		    m_codec_context->height,
+		    AV_PIX_FMT_RGBA,
+		    m_codec_context->pix_fmt,
+		    SWS_CS_ITU709,
+		    m_threads);
+	}
+
+	const uint8_t* data[4] = { reinterpret_cast<const uint8_t*>(image.data()), nullptr, nullptr, nullptr };
+	int stride[4] = { static_cast<int>(image.row_stride() * sizeof(Rgba<uint8_t>)), 0, 0, 0 };
+
+	std::unique_ptr<AVFrame, internal::AVFrameDeleter> output_frame(av_frame_alloc());
+	output_frame->width = m_codec_context->width;
+	output_frame->height = m_codec_context->height;
+	output_frame->format = m_codec_context->pix_fmt;
+	output_frame->colorspace = m_codec_context->colorspace;
+	output_frame->color_primaries = m_codec_context->color_primaries;
+	output_frame->color_trc = m_codec_context->color_trc;
+	output_frame->sample_aspect_ratio = m_codec_context->sample_aspect_ratio;
+	auto timebase_ratio = divide_rational(m_timebase, m_format_context->streams[0]->time_base);
+	output_frame->pts = (pts * timebase_ratio.num + timebase_ratio.den / 2) / timebase_ratio.den;
+	internal::CheckAVError(av_frame_get_buffer(output_frame.get(), 32));
+
+	m_scaler->scale(data, stride, 0, image.size().y, output_frame->data, output_frame->linesize);
+
+	internal::SendFrame(m_format_context.get(), m_codec_context.get(), output_frame.get());
+}
+
+VideoWriter::~VideoWriter()
+{
+	if(m_scaler)
+	{
+		internal::SendFrame(m_format_context.get(), m_codec_context.get(), nullptr);
+		internal::CheckAVError(av_write_trailer(m_format_context.get()));
+	}
+}
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,4 +27,8 @@ if(CVD_HAVE_FFMPEG)
 	add_executable(videoreader_test videoreader_test.cc)
 	target_link_libraries(videoreader_test PRIVATE CVD)
 	add_test(NAME videoreader_test COMMAND videoreader_test ${CMAKE_CURRENT_LIST_DIR}/videoreader_test.mp4)
+
+	add_executable(videowriter_test videowriter_test.cc)
+	target_link_libraries(videowriter_test PRIVATE CVD)
+	add_test(NAME videowriter_test COMMAND videowriter_test ${CMAKE_CURRENT_BINARY_DIR}/videowriter_test.mp4)
 endif()

--- a/tests/videowriter_test.cc
+++ b/tests/videowriter_test.cc
@@ -1,0 +1,147 @@
+/*
+	This file is part of the CVD Library.
+
+	Copyright (C) 2022 The Authors
+
+	This library is free software, see LICENSE file for details
+*/
+#include <cvd/videowriter.h>
+
+#include <cvd/image.h>
+#include <cvd/rgba.h>
+#include <cvd/videoreader.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+namespace
+{
+using CVD::Image;
+using CVD::ImageRef;
+using CVD::Rgba;
+using CVD::VideoReader;
+using CVD::VideoWriter;
+using std::uint8_t;
+
+template <typename T>
+void assert_equal(T expected, T actual, std::string message)
+{
+	if(expected != actual)
+	{
+		std::cerr << message << "; expected " << expected << ", actual " << actual << "\n";
+		exit(EXIT_FAILURE);
+	}
+}
+
+void assert_near(Rgba<uint8_t> expected, Rgba<uint8_t> actual, std::string message)
+{
+	int diff = std::max({
+	    std::abs(static_cast<int>(expected.red) - actual.red),
+	    std::abs(static_cast<int>(expected.green) - actual.green),
+	    std::abs(static_cast<int>(expected.blue) - actual.blue),
+	    std::abs(static_cast<int>(expected.alpha) - actual.alpha),
+	});
+	if(diff > 5)
+	{
+		std::cerr << message << "; expected " << expected << ", actual " << actual << "\n";
+		exit(EXIT_FAILURE);
+	}
+}
+}
+
+int main(int argc, char* argv[])
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " videowriter.mp4\n";
+		exit(EXIT_FAILURE);
+	}
+	{
+		VideoWriter writer(argv[1], "mpeg4", "yuv420p", { 1, 10240 }, { 10, 1 }, 0, 4);
+
+		Image<Rgba<uint8_t>> image(ImageRef { 128, 128 });
+		for(int j = 0; j < image.size().y; ++j)
+		{
+			for(int i = 0; i < image.size().x; ++i)
+			{
+				if(i >= 64)
+				{
+					if(j >= 64)
+						image[j][i] = Rgba<uint8_t>(0, 0, 255, 255);
+					else
+						image[j][i] = Rgba<uint8_t>(255, 0, 0, 255);
+				}
+				else
+				{
+					if(j >= 64)
+						image[j][i] = Rgba<uint8_t>(0, 255, 0, 255);
+					else
+						image[j][i] = Rgba<uint8_t>(0, 0, 0, 255);
+				}
+			}
+		}
+		for(int i = 0; i < 10; ++i)
+		{
+			writer.put_frame(image, i * 1024);
+		}
+		for(int j = 0; j < image.size().y; ++j)
+		{
+			for(int i = 0; i < image.size().x; ++i)
+			{
+				if(i >= 64)
+				{
+					if(j >= 64)
+						image[j][i] = Rgba<uint8_t>(255, 255, 0, 255);
+					else
+						image[j][i] = Rgba<uint8_t>(0, 255, 255, 255);
+				}
+				else
+				{
+					if(j >= 64)
+						image[j][i] = Rgba<uint8_t>(255, 0, 255, 255);
+					else
+						image[j][i] = Rgba<uint8_t>(0, 0, 0, 255);
+				}
+			}
+		}
+		for(int i = 10; i < 20; ++i)
+		{
+			writer.put_frame(image, i * 1024);
+		}
+	}
+
+	VideoReader reader(argv[1], 4);
+	assert_equal(1, reader.timebase().num, "Incorrect timebase numerator");
+	assert_equal(10240, reader.timebase().den, "Incorrect timebase denominator");
+	for(int i = 0; i < 20; ++i)
+	{
+		auto [frame, timestamp] = reader.get_frame();
+
+		int64_t expected_timestamp = i * 1024;
+		assert_equal(expected_timestamp, timestamp, "Incorrect timestamp for frame " + std::to_string(i));
+
+		if(i < 10)
+		{
+			assert_near(Rgba<uint8_t>(0, 0, 0, 255), frame[32][32], "Incorrect top left square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(255, 0, 0, 255), frame[32][96], "Incorrect top right square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(0, 255, 0, 255), frame[96][32], "Incorrect bottom left square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(0, 0, 255, 255), frame[96][96], "Incorrect bottom right square on frame " + std::to_string(i));
+		}
+		else
+		{
+			assert_near(Rgba<uint8_t>(0, 0, 0, 255), frame[32][32], "Incorrect top left square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(0, 255, 255, 255), frame[32][96], "Incorrect top right square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(255, 0, 255, 255), frame[96][32], "Incorrect bottom left square on frame " + std::to_string(i));
+			assert_near(Rgba<uint8_t>(255, 255, 0, 255), frame[96][96], "Incorrect bottom right square on frame " + std::to_string(i));
+		}
+	}
+
+	auto [frame, timestamp] = reader.get_frame();
+	if(frame.size().x != 0)
+	{
+		std::cerr << "Expected end of stream, received frame\n";
+		exit(EXIT_FAILURE);
+	}
+}


### PR DESCRIPTION
This change adds a simple video writer. The writer supports only 8-bit RGBA frames. It supports specifying the codec and pixel format by name, and the timebase explicitly to match the timebase from `VideoReader`.