### PR TITLE
Add more OpenCV wrappers and test utilities

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -42,7 +42,7 @@ jobs:
       run: cmake -DCMAKE_BUILD_TYPE=Debug -DCVD_ENABLE_OPENCV_TESTS=ON ..
       env: 
         CC: gcc-10
-        CXX: g++-10 -Werror -fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_DEBUG -DCVD_IMAGE_DEBUG -DTIFF_DISABLE_DEPRECATED -Wno-error=stringop-overflow
+        CXX: g++-10 -Werror -fsanitize=address,undefined -fno-omit-frame-pointer -DCVD_IMAGE_DEBUG -DTIFF_DISABLE_DEPRECATED -Wno-error=stringop-overflow
     - name: make
       run: make
       working-directory: ./build

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,13 +33,13 @@ jobs:
     steps:
     - run: |
            sudo apt-get update
-           sudo apt install g++-10 gcc-10 cmake libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev libswscale-dev
+           sudo apt install g++-10 gcc-10 cmake libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev libswscale-dev libeigen3-dev libopencv-dev libtoon-dev
     - uses: actions/checkout@v2
     - name: setup
       run: mkdir build
     - name: configure
       working-directory: ./build
-      run: cmake -DCMAKE_BUILD_TYPE=DEBUG ..
+      run: cmake -DCMAKE_BUILD_TYPE=Debug -DCVD_ENABLE_OPENCV_TESTS=ON ..
       env: 
         CC: gcc-10
         CXX: g++-10 -Werror -fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_DEBUG -DCVD_IMAGE_DEBUG -DTIFF_DISABLE_DEPRECATED -Wno-error=stringop-overflow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ enable_testing()
 option(CVD_ENABLE_TESTS "Build libCVD tests" ON)
 option(CVD_ENABLE_PROGS "Build libCVD programs" ON)
 option(CVD_ENABLE_EXAMPLES "Build libCVD examples" ON)
+option(CVD_ENABLE_OPENCV_TESTS "Build libCVD tests that rely on OpenCV" OFF)
 
 include(TestBigEndian)
 include(CheckSymbolExists)

--- a/cvd/opencv.h
+++ b/cvd/opencv.h
@@ -50,5 +50,35 @@ void equalizeHist(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out)
 {
 	equalizeHist(toMat(in), toMat(out));
 }
+
+namespace OpenCV
+{
+	struct ContourHierarchy
+	{
+		int next_index;
+		int previous_index;
+		int first_child_index;
+		int parent_index;
+	};
+
+	namespace Internal
+	{
+		void convert_hierarchy(const std::vector<cv::Vec4i>& cv_hierarchy, std::vector<ContourHierarchy>& hierarchy)
+		{
+			hierarchy.reserve(cv_hierarchy.size());
+			std::transform(
+			    cv_hierarchy.begin(),
+			    cv_hierarchy.end(),
+			    std::back_inserter(hierarchy),
+			    [](const cv::Vec4i& p) { return ContourHierarchy { p[0], p[1], p[2], p[3] }; });
+		}
+	}
+
+	template <typename T>
+	void resize(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out, int interpolation = cv::INTER_LINEAR)
+	{
+		cv::resize(toMat(in), toMat(out), cv::Size(out.size().x, out.size().y), 0, 0, interpolation);
+	}
+}
 }
 #endif

--- a/cvd/opencv_eigen.h
+++ b/cvd/opencv_eigen.h
@@ -1,0 +1,86 @@
+#ifndef LIBCVD_OPENCV_EIGEN_H
+#define LIBCVD_OPENCV_EIGEN_H
+
+#include "opencv.h"
+
+#include <Eigen/Core>
+#include <opencv2/core/eigen.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <vector>
+
+namespace CVD
+{
+namespace OpenCV
+{
+	namespace Internal
+	{
+		void convert_contours(const std::vector<std::vector<cv::Point2i>>& cv_contours, std::vector<std::vector<Eigen::Vector2i>>& contours)
+		{
+			for(const auto& cv_contour : cv_contours)
+			{
+				auto& contour = contours.emplace_back();
+				contour.reserve(cv_contour.size());
+				std::transform(
+				    cv_contour.begin(),
+				    cv_contour.end(),
+				    std::back_inserter(contour),
+				    [](const cv::Point2i& p) { return Eigen::Vector2i(p.x, p.y); });
+			}
+		}
+	}
+
+	template <typename T, typename U, int Options, int MaxRows, int MaxCols>
+	void warpAffine(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out, const Eigen::Matrix<U, 2, 3, Options, MaxRows, MaxCols>& M, int flags = cv::INTER_LINEAR, int borderMode = cv::BORDER_CONSTANT, const T& borderValue = T())
+	{
+		cv::Mat m_mat;
+		cv::eigen2cv(M, m_mat);
+		cv::warpAffine(toMat(in), toMat(out), m_mat, cv::Size(out.size().x, out.size().y), flags, borderMode, borderValue);
+	}
+
+	template <typename T, typename U, int Options, int MaxRows, int MaxCols>
+	void warpPerspective(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out, const Eigen::Matrix<U, 3, 3, Options, MaxRows, MaxCols>& M, int flags = cv::INTER_LINEAR, int borderMode = cv::BORDER_CONSTANT, const T& borderValue = T())
+	{
+		cv::Mat m_mat;
+		cv::eigen2cv(M, m_mat);
+		cv::warpPerspective(toMat(in), toMat(out), m_mat, cv::Size(out.size().x, out.size().y), flags, borderMode, borderValue);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::uint8_t>& in, std::vector<std::vector<Eigen::Vector2i>>& contours, cv::RetrievalModes mode, cv::ContourApproximationModes method, const Eigen::Vector2i& offset = { 0, 0 })
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		cv::findContours(toMat(in), cv_contours, mode, method, { offset.x(), offset.y() });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::int32_t>& in, std::vector<std::vector<Eigen::Vector2i>>& contours, cv::ContourApproximationModes method, const Eigen::Vector2i& offset = { 0, 0 })
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		cv::findContours(toMat(in), cv_contours, cv::RETR_FLOODFILL, method, { offset.x(), offset.y() });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::uint8_t>& in, std::vector<std::vector<Eigen::Vector2i>>& contours, std::vector<ContourHierarchy>& hierarchy, cv::RetrievalModes mode, cv::ContourApproximationModes method, const Eigen::Vector2i& offset = { 0, 0 })
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		std::vector<cv::Vec4i> cv_hierarchy;
+		cv::findContours(toMat(in), cv_contours, cv_hierarchy, mode, method, { offset.x(), offset.y() });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+		CVD::OpenCV::Internal::convert_hierarchy(cv_hierarchy, hierarchy);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::int32_t>& in, std::vector<std::vector<Eigen::Vector2i>>& contours, std::vector<ContourHierarchy>& hierarchy, cv::ContourApproximationModes method, const Eigen::Vector2i& offset = { 0, 0 })
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		std::vector<cv::Vec4i> cv_hierarchy;
+		cv::findContours(toMat(in), cv_contours, cv_hierarchy, cv::RETR_FLOODFILL, method, { offset.x(), offset.y() });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+		CVD::OpenCV::Internal::convert_hierarchy(cv_hierarchy, hierarchy);
+	}
+}
+}
+
+#endif

--- a/cvd/opencv_toon.h
+++ b/cvd/opencv_toon.h
@@ -1,0 +1,79 @@
+#ifndef LIBCVD_OPENCV_TOON_H
+#define LIBCVD_OPENCV_TOON_H
+
+#include "opencv.h"
+
+#include <opencv2/imgproc.hpp>
+
+#include <TooN/TooN.h>
+
+namespace CVD
+{
+namespace OpenCV
+{
+	namespace Internal
+	{
+		void convert_contours(const std::vector<std::vector<cv::Point2i>>& cv_contours, std::vector<std::vector<TooN::Vector<2, int>>>& contours)
+		{
+			for(const auto& cv_contour : cv_contours)
+			{
+				auto& contour = contours.emplace_back();
+				contour.reserve(cv_contour.size());
+				std::transform(
+				    cv_contour.begin(),
+				    cv_contour.end(),
+				    std::back_inserter(contour),
+				    [](const cv::Point2i& p) { return TooN::makeVector(p.x, p.y); });
+			}
+		}
+	}
+
+	template <typename T, typename U>
+	void warpAffine(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out, const TooN::Matrix<2, 3, U>& M, int flags = cv::INTER_LINEAR, int borderMode = cv::BORDER_CONSTANT, const T& borderValue = T())
+	{
+		cv::Mat m_mat(2, 3, CVD::Internal::opencv_type<U>::type, const_cast<U*>(&M(0, 0)));
+		cv::warpAffine(toMat(in), toMat(out), m_mat, cv::Size(out.size().x, out.size().y), flags, borderMode, borderValue);
+	}
+
+	template <typename T, typename U>
+	void warpPerspective(const CVD::BasicImage<T>& in, CVD::BasicImage<T>& out, const TooN::Matrix<3, 3, U>& M, int flags = cv::INTER_LINEAR, int borderMode = cv::BORDER_CONSTANT, const T& borderValue = T())
+	{
+		cv::Mat m_mat(3, 3, CVD::Internal::opencv_type<U>::type, const_cast<U*>(&M(0, 0)));
+		cv::warpPerspective(toMat(in), toMat(out), m_mat, cv::Size(out.size().x, out.size().y), flags, borderMode, borderValue);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::uint8_t>& in, std::vector<std::vector<TooN::Vector<2, int>>>& contours, cv::RetrievalModes mode, cv::ContourApproximationModes method, const TooN::Vector<2, int>& offset = TooN::makeVector(0, 0))
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		cv::findContours(toMat(in), cv_contours, mode, method, { offset[0], offset[1] });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::int32_t>& in, std::vector<std::vector<TooN::Vector<2, int>>>& contours, cv::ContourApproximationModes method, const TooN::Vector<2, int>& offset = TooN::makeVector(0, 0))
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		cv::findContours(toMat(in), cv_contours, cv::RETR_FLOODFILL, method, { offset[0], offset[1] });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::uint8_t>& in, std::vector<std::vector<TooN::Vector<2, int>>>& contours, std::vector<ContourHierarchy>& hierarchy, cv::RetrievalModes mode, cv::ContourApproximationModes method, const TooN::Vector<2, int>& offset = TooN::makeVector(0, 0))
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		std::vector<cv::Vec4i> cv_hierarchy;
+		cv::findContours(toMat(in), cv_contours, cv_hierarchy, mode, method, { offset[0], offset[1] });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+		CVD::OpenCV::Internal::convert_hierarchy(cv_hierarchy, hierarchy);
+	}
+
+	inline void findContours(const CVD::BasicImage<std::int32_t>& in, std::vector<std::vector<TooN::Vector<2, int>>>& contours, std::vector<ContourHierarchy>& hierarchy, cv::ContourApproximationModes method, const TooN::Vector<2, int>& offset = TooN::makeVector(0, 0))
+	{
+		std::vector<std::vector<cv::Point2i>> cv_contours;
+		std::vector<cv::Vec4i> cv_hierarchy;
+		cv::findContours(toMat(in), cv_contours, cv_hierarchy, cv::RETR_FLOODFILL, method, { offset[0], offset[1] });
+		CVD::OpenCV::Internal::convert_contours(cv_contours, contours);
+		CVD::OpenCV::Internal::convert_hierarchy(cv_hierarchy, hierarchy);
+	}
+}
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,12 @@ if(CVD_HAVE_FFMPEG)
 	target_link_libraries(videoreader_test PRIVATE CVD)
 	add_test(NAME videoreader_test COMMAND videoreader_test ${CMAKE_CURRENT_LIST_DIR}/videoreader_test.mp4)
 endif()
+
+if(CVD_ENABLE_OPENCV_TESTS)
+	# test only, carries no binary dependency
+	find_package(OpenCV REQUIRED)
+	find_package(Eigen3 REQUIRED)
+	add_executable(opencv_test opencv_test.cc)
+	target_link_libraries(opencv_test PRIVATE CVD Eigen3::Eigen ${OpenCV_LIBS})
+	add_test(NAME opencv_test COMMAND opencv_test)
+endif()

--- a/tests/flips.cc
+++ b/tests/flips.cc
@@ -1,70 +1,38 @@
-#include <chrono>
+#include "test_utility.h"
+
 #include <cvd/image.h>
 #include <cvd/vision.h>
+
+#include <chrono>
 #include <random>
 
 using CVD::Image;
 using CVD::ImageRef;
-using CVD::SubImage;
-
-Image<int> im(int x, int y, const std::initializer_list<int>& data)
-{
-	if(ImageRef(x, y).area() != (int)data.size())
-		abort();
-
-	return SubImage<int>(const_cast<int*>(std::data(data)), ImageRef(x, y));
-}
+using CVD::Testing::assert_equal;
+using CVD::Testing::assert_image_equal;
+using CVD::Testing::init;
 
 int main()
 {
-
-	Image<int> a;
-
-	a = im(2, 2,
-	    { 1, 2,
-	        3, 4 });
-
+	Image<int> a = init({ { 1, 2 }, { 3, 4 } });
 	flipVertical(a);
-
-	if(!std::equal(a.begin(), a.end(), im(2, 2, { 3, 4, 1, 2 }).begin()))
-		throw std::logic_error("Even sized flipV failed");
+	assert_image_equal(init({ { 3, 4 }, { 1, 2 } }), a, "Even sized flipV failed");
 
 	////////////////////////////////////////////////////////////////////////////////
-	a = im(2, 3,
-	    { 1, 2,
-	        3, 4,
-	        5, 6 });
-
+	a = init({ { 1, 2 }, { 3, 4 }, { 5, 6 } });
 	flipVertical(a);
-
-	if(!std::equal(a.begin(), a.end(), im(2, 3, { 5, 6, 3, 4, 1, 2 }).begin()))
-		throw std::logic_error("Odd sized flipV failed");
+	assert_image_equal(init({ { 5, 6 }, { 3, 4 }, { 1, 2 } }), a, "Odd sized flipV failed");
 
 	////////////////////////////////////////////////////////////////////////////////
-
-	a = im(2, 3,
-	    { 1, 2,
-	        3, 4,
-	        5, 6 });
-
+	a = init({ { 1, 2 }, { 3, 4 }, { 5, 6 } });
 	Image<int> b(a.size().transpose());
 	CVD::Internal::simpleTranspose(a, b);
-
-	if(!std::equal(b.begin(), b.end(), im(2, 3, { 1, 3, 5, 2, 4, 6 }).begin()))
-		throw std::logic_error("Simple transpose failed");
+	assert_image_equal(init({ { 1, 3, 5 }, { 2, 4, 6 } }), b, "Simple transpose failed");
 
 	////////////////////////////////////////////////////////////////////////////////
-
-	a = im(2, 3,
-	    { 1, 2,
-	        3, 4,
-	        5, 6 });
-
 	b.resize(a.size().transpose());
 	CVD::Internal::recursiveTranspose(a, b, 1);
-
-	if(!std::equal(b.begin(), b.end(), im(2, 3, { 1, 3, 5, 2, 4, 6 }).begin()))
-		throw std::logic_error("Recursive transpose failed (small)");
+	assert_image_equal(init({ { 1, 3, 5 }, { 2, 4, 6 } }), b, "Recursive transpose failed (small)");
 
 	////////////////////////////////////////////////////////////////////////////////
 	const int N = 100;
@@ -96,8 +64,7 @@ int main()
 			CVD::Internal::simpleTranspose(im1, simple);
 			auto t3 = std::chrono::steady_clock::now();
 
-			if(!std::equal(simple.begin(), simple.end(), recurs.begin()))
-				throw std::logic_error("Recursive transpose failed");
+			CVD::Testing::assert_image_equal(simple, recurs);
 
 			s_recursive += std::chrono::duration<double>(t2 - t1).count();
 			s_simple += std::chrono::duration<double>(t3 - t2).count();

--- a/tests/image_ref.cc
+++ b/tests/image_ref.cc
@@ -1,4 +1,7 @@
+#include "test_utility.h"
+
 #include <cvd/image_ref.h>
+
 #include <iostream>
 
 using namespace std;
@@ -24,6 +27,5 @@ int main()
 	Fun<i[0]> {};
 	Fun<i.x> {};
 
-	if(foo(i) != ImageRef(16, 20))
-		return 1;
+	CVD::Testing::assert_equal(ImageRef(16, 20), foo(i));
 }

--- a/tests/opencv_test.cc
+++ b/tests/opencv_test.cc
@@ -1,0 +1,92 @@
+/*
+	This file is part of the CVD Library.
+
+	Copyright (C) 2022 The Authors
+
+	This library is free software, see LICENSE file for details
+*/
+#include "test_utility.h"
+
+#include <cvd/opencv.h>
+#include <cvd/opencv_eigen.h>
+#include <cvd/opencv_toon.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+using CVD::Testing::assert_equal;
+using CVD::Testing::assert_image_equal;
+using CVD::Testing::assert_vector_equal;
+using CVD::Testing::init;
+
+template <typename T, int Rows, int Cols, int Options>
+TooN::Matrix<Rows, Cols, T> ToTooN(const Eigen::Matrix<T, Rows, Cols, Options>& m)
+{
+	if constexpr(Options & Eigen::RowMajor)
+	{
+		return TooN::Matrix<Rows, Cols, T, TooN::Reference::RowMajor>(const_cast<T*>(m.data()));
+	}
+	else
+	{
+		return TooN::Matrix<Rows, Cols, T, TooN::Reference::ColMajor>(const_cast<T*>(m.data()));
+	}
+}
+}
+
+int main()
+{
+	CVD::Image<float> in = init<float>({ { 1, 2 }, { 3, 4 } });
+	CVD::Image<float> out({ 4, 4 });
+	Eigen::Matrix<double, 2, 3> transformation;
+	transformation << 0, -1, 2,
+	    1, 0, 1;
+	CVD::OpenCV::warpAffine(in, out, transformation, cv::INTER_NEAREST);
+	assert_image_equal(init<float>({
+	                       { 0, 0, 0, 0 },
+	                       { 0, 3, 1, 0 },
+	                       { 0, 4, 2, 0 },
+	                       { 0, 0, 0, 0 },
+	                   }),
+	    out);
+
+	CVD::Image<float> toon_out({ 4, 4 });
+	double values[6] = { 0, -1, 2, 1, 0, 1 };
+	TooN::Matrix<2, 3> toon_transform = ToTooN(transformation);
+	CVD::OpenCV::warpAffine(in, toon_out, toon_transform, cv::INTER_NEAREST);
+	assert_image_equal(init<float>({
+	                       { 0, 0, 0, 0 },
+	                       { 0, 3, 1, 0 },
+	                       { 0, 4, 2, 0 },
+	                       { 0, 0, 0, 0 },
+	                   }),
+	    toon_out);
+
+	CVD::Image<std::uint8_t> mask = init<std::uint8_t>({
+	    { 0, 0, 0, 0, 0, 0 },
+	    { 0, 0, 1, 1, 0, 0 },
+	    { 0, 1, 1, 1, 1, 0 },
+	    { 0, 1, 1, 1, 1, 0 },
+	    { 0, 0, 1, 1, 0, 0 },
+	    { 0, 0, 0, 0, 0, 0 },
+	});
+	std::vector<std::vector<Eigen::Vector2i>> contours;
+	CVD::OpenCV::findContours(mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+	assert_equal(static_cast<size_t>(1), contours.size());
+	assert_vector_equal(std::vector<Eigen::Vector2i> { { 2, 1 }, { 1, 2 }, { 1, 3 }, { 2, 4 }, { 3, 4 }, { 4, 3 }, { 4, 2 }, { 3, 1 } }, contours[0]);
+
+	std::vector<std::vector<TooN::Vector<2, int>>> toon_contours;
+	CVD::OpenCV::findContours(mask, toon_contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+	assert_equal(static_cast<size_t>(1), toon_contours.size());
+	assert_vector_equal(std::vector<TooN::Vector<2, int>> {
+	                        TooN::makeVector(2, 1),
+	                        TooN::makeVector(1, 2),
+	                        TooN::makeVector(1, 3),
+	                        TooN::makeVector(2, 4),
+	                        TooN::makeVector(3, 4),
+	                        TooN::makeVector(4, 3),
+	                        TooN::makeVector(4, 2),
+	                        TooN::makeVector(3, 1) },
+	    toon_contours[0]);
+}

--- a/tests/test_utility.h
+++ b/tests/test_utility.h
@@ -4,6 +4,8 @@
 #include <cvd/image.h>
 #include <cvd/rgba.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>

--- a/tests/test_utility.h
+++ b/tests/test_utility.h
@@ -1,0 +1,132 @@
+#ifndef LIBCVD_TEST_UTILITY_H
+#define LIBCVD_TEST_UTILITY_H
+
+#include <cvd/image.h>
+#include <cvd/rgba.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace CVD
+{
+namespace Testing
+{
+	template <typename T>
+	void dump(const CVD::BasicImage<T>& im, std::ostream& stream = std::cout)
+	{
+		for(int j = 0; j < im.size().y; ++j)
+		{
+			for(int i = 0; i < im.size().x; ++i)
+			{
+				stream << im[j][i] << " ";
+			}
+			stream << "\n";
+		}
+	}
+
+	template <typename T>
+	CVD::Image<T> init(std::initializer_list<std::initializer_list<T>> values)
+	{
+		CVD::Image<T> image({ static_cast<int>(values.begin()->size()), static_cast<int>(values.size()) });
+		int j = 0;
+		for(const auto& row : values)
+		{
+			int i = 0;
+			for(const auto& value : row)
+			{
+				image[j][i] = value;
+				++i;
+			}
+			++j;
+		}
+		return image;
+	}
+
+	template <typename T>
+	void assert_equal(T expected, T actual, std::string message = "");
+
+	template <typename T>
+	void assert_image_equal(const CVD::BasicImage<T>& expected, const CVD::BasicImage<T>& actual, std::string message = "")
+	{
+		assert_equal(expected.size(), actual.size(), message);
+		if(expected.size() != actual.size())
+		{
+			exit(EXIT_FAILURE);
+		}
+		for(int j = 0; j < expected.size().y; ++j)
+		{
+			for(int i = 0; i < expected.size().x; ++i)
+			{
+				if(expected[j][i] != actual[j][i])
+				{
+					if(!message.empty())
+					{
+						std::cerr << message << ": ";
+					}
+					std::cerr << "expected:\n";
+					dump(expected, std::cerr);
+					std::cerr << "actual:\n";
+					dump(actual, std::cerr);
+					exit(EXIT_FAILURE);
+				}
+			}
+		}
+	}
+
+	template <typename T>
+	void assert_vector_equal(const std::vector<T>& expected, const std::vector<T>& actual, std::string message = "")
+	{
+		assert_equal(expected.size(), actual.size(), message);
+		for(size_t i = 0; i < expected.size(); ++i)
+		{
+			if(expected[i] != actual[i])
+			{
+				if(!message.empty())
+				{
+					std::cerr << message << ": ";
+				}
+				std::cerr << "item " << i << ": expected " << expected[i] << ", actual " << actual[i] << "\n";
+				exit(EXIT_FAILURE);
+			}
+		}
+	}
+
+	template <typename T>
+	void assert_equal(T expected, T actual, std::string message)
+	{
+		if(expected != actual)
+		{
+			if(!message.empty())
+			{
+				std::cerr << message << "; ";
+			}
+			std::cerr << "expected " << expected << ", actual " << actual << "\n";
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	template <typename T>
+	void assert_near(Rgba<T> expected, Rgba<T> actual, std::string message = "")
+	{
+		int diff = std::max({
+		    std::abs(static_cast<int>(expected.red) - actual.red),
+		    std::abs(static_cast<int>(expected.green) - actual.green),
+		    std::abs(static_cast<int>(expected.blue) - actual.blue),
+		    std::abs(static_cast<int>(expected.alpha) - actual.alpha),
+		});
+		if(diff > 5)
+		{
+			if(!message.empty())
+			{
+				std::cerr << message << "; ";
+			}
+			std::cerr << "expected " << expected << ", actual " << actual << "\n";
+			exit(EXIT_FAILURE);
+		}
+	}
+}
+}
+
+#endif

--- a/tests/videoreader_test.cc
+++ b/tests/videoreader_test.cc
@@ -7,6 +7,8 @@
 */
 #include <cvd/videoreader.h>
 
+#include "test_utility.h"
+
 #include <cvd/rgba.h>
 
 #include <algorithm>
@@ -17,31 +19,8 @@ namespace
 {
 using CVD::Rgba;
 using CVD::VideoReader;
-
-template <typename T>
-void assert_equal(T expected, T actual, std::string message)
-{
-	if(expected != actual)
-	{
-		std::cerr << message << "; expected " << expected << ", actual " << actual << "\n";
-		exit(EXIT_FAILURE);
-	}
-}
-
-void assert_near(Rgba<uint8_t> expected, Rgba<uint8_t> actual, std::string message)
-{
-	int diff = std::max({
-	    std::abs(static_cast<int>(expected.red) - actual.red),
-	    std::abs(static_cast<int>(expected.green) - actual.green),
-	    std::abs(static_cast<int>(expected.blue) - actual.blue),
-	    std::abs(static_cast<int>(expected.alpha) - actual.alpha),
-	});
-	if(diff > 5)
-	{
-		std::cerr << message << "; expected " << expected << ", actual " << actual << "\n";
-		exit(EXIT_FAILURE);
-	}
-}
+using CVD::Testing::assert_equal;
+using CVD::Testing::assert_near;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This change adds a few more OpenCV wrappers to ease porting of code from OpenCV to libcvd. The wrapped functions herein are:

- `warpAffine`
- `warpPerspective`
- `findContours`

This change also adds a handful of test utilities so that they don't need to be copied from test to test:

- `assert_equal`, `assert_image_equal` and `assert_vector_equal` to check for equality
- `init`, to construct an image from an initializer list
- `dump`, to dump an image to a stream