### PR TITLE
Make convert_hierarchy inline to prevent duplicate symbols

### DIFF
--- a/cvd/opencv.h
+++ b/cvd/opencv.h
@@ -63,7 +63,7 @@ namespace OpenCV
 
 	namespace Internal
 	{
-		void convert_hierarchy(const std::vector<cv::Vec4i>& cv_hierarchy, std::vector<ContourHierarchy>& hierarchy)
+		inline void convert_hierarchy(const std::vector<cv::Vec4i>& cv_hierarchy, std::vector<ContourHierarchy>& hierarchy)
 		{
 			hierarchy.reserve(cv_hierarchy.size());
 			std::transform(


### PR DESCRIPTION
Without inline, this function will have strong symbol type and will result in duplicate symbols linking error if this header gets included in more than one .cpp file.
See here https://en.cppreference.com/w/cpp/language/inline
>> There may be more than one definition of an inline function or variable (since C++17) in the program as long as each definition appears in a different translation unit and (for non-static inline functions and variables (since C++17)) all definitions are identical. For example, an inline function or an inline variable (since C++17) may be defined in a header file that is included in multiple source files.

Errors example: 
```
duplicate symbol 'CVD::OpenCV::Internal::convert_hierarchy(std::__1::vector<cv::Vec<int, 4>, std::__1::allocator<cv::Vec<int, 4> > > const&, std::__1::vector<CVD::OpenCV::ContourHierarchy, std::__1::allocator<CVD::OpenCV::ContourHierarchy> >&)' in:
dep_1/CMakeFiles/1.dir/src/code_path_1cpp.o
dep_1/CMakeFiles/1.dir/src/code_path_2.cpp.o
```