### PR TITLE
Fix 'cvd/convert_image.h' not being installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(HEADERS
 	cvd/colourspace_convert.h
 	cvd/colourspace_frame.h
 	cvd/connected_components.h
+	cvd/convert_image.h
 	cvd/convolution.h
 	cvd/deinterlacebuffer.h
 	cvd/deinterlaceframe.h


### PR DESCRIPTION
I'm in the process of creating a Conan package of libCVD and https://github.com/edrosten/libcvd/blob/main/examples/distance_transform.cc example fails for installed libCVD due to this bug currently.