### PR TITLE
Build tests without -O0 also in the autoconf build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -295,7 +295,7 @@ REGRESSION_OUT=$(patsubst %,tests/%.out, $(REGRESSIONS))
 test:$(REGRESSION_OUT)
 .PRECIOUS:tests/%.test
 tests/%.test: tests/%.cc 
-	mkdir -p $(@D) && $(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@ -O0 -L. -lcvd -MMD -MP -MF tests/$*.d
+	mkdir -p $(@D) && $(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -o $@ -L. -lcvd -MMD -MP -MF tests/$*.d
 
 .PRECIOUS:tests/%.out
 tests/videoreader_test.out: tests/videoreader_test.test


### PR DESCRIPTION
C++ code compiled without optimizations can be inefficient in many ways, and on some more exotic architectures (MIPS, Alpha) this caused a build failure:
https://buildd.debian.org/status/fetch.php?pkg=libcvd&arch=mips64el&ver=0.0%7Egit20221020150751.30e8cfc%2Bds1-1&stamp=1695631656&raw=0
https://buildd.debian.org/status/fetch.php?pkg=libcvd&arch=alpha&ver=0.0%7Egit20221020150751.30e8cfc%2Bds1-1&stamp=1722259419&raw=0

```
/usr/bin/ld: /tmp/cc5JDH6b.o: .got subsegment exceeds 64K (size 86336)
/usr/bin/ld: failed to set dynamic section sizes: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:298: tests/load_and_save.test] Error 1
```

CMake is already using the normal optimization flags also for building the tests.